### PR TITLE
ci: add mypy type checking step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
           pip install -e .
           pip install -r requirements-dev.txt
 
+      - name: Type checking
+        run: mypy src/
+
       - name: Download Antares v9.3.7 release
         run: |
           echo "Downloading Antares v9.3.7..."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,5 +34,9 @@ include = '\.pyi?$'
 [tool.isort]
 profile = "black"
 
+[tool.mypy]
+files = ["src"]
+ignore_missing_imports = true
+
 [tool.coverage.run]
 source = ["src"]

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,3 +1,5 @@
 -r requirements.txt
 pytest~=7.0.0
 pytest-cov
+mypy
+types-PyYAML


### PR DESCRIPTION
Adds a mypy step to CI after the Black formatting check. Configures mypy in pyproject.toml with ignore_missing_imports=true to handle third-party libraries without stubs. Adds mypy and types-PyYAML to requirements-dev.in.