### PR TITLE
Fix template resolution logic in model conversion

### DIFF
--- a/src/antares_gems_converter/input_converter/src/converter.py
+++ b/src/antares_gems_converter/input_converter/src/converter.py
@@ -324,6 +324,10 @@ class AntaresStudyConverter:
                 self.logger.warning(
                     f"Item {legacy_component} will not be deleted because it is referenced in a binding constraint"
                 )
+            except KeyError:
+                self.logger.warning(
+                    f"Item {legacy_component} not found in study; skipping deletion"
+                )
             except NotImplementedError:
                 self.logger.warning(
                     f"Failure to delete {legacy_component} because the method is not implemented yet on antares craft"
@@ -462,7 +466,7 @@ class AntaresStudyConverter:
                     return components, connections, area_connections
                 for area in self.areas.values():
                     if area.id not in virtual_objects.areas:
-                        resolved_template = conversion_template.resolve_template(
+                        area_resolved_template = conversion_template.resolve_template(
                             model_area_pattern, area.id
                         )
                         cluster_type = next(
@@ -477,11 +481,14 @@ class AntaresStudyConverter:
                                 area, TEMPLATE_CLUSTER_TYPE_TO_GET_METHOD[cluster_type]
                             )():
                                 # We have already resolved areas, now need to resolve cluster ids
-                                resolved_template = resolved_template.resolve_template(
-                                    f"${{{cluster_type}}}", cluster_id
+                                # Resolve from the area-resolved template, not from the previous cluster-resolved template
+                                cluster_resolved_template = (
+                                    area_resolved_template.resolve_template(
+                                        f"${{{cluster_type}}}", cluster_id
+                                    )
                                 )
                                 self._iterate_through_model(
-                                    resolved_template,
+                                    cluster_resolved_template,
                                     components,
                                     connections,
                                     area_connections,
@@ -493,10 +500,10 @@ class AntaresStudyConverter:
                                 model_preprocessor.check_timeseries_validity(
                                     param.value
                                 )
-                                for param in resolved_template.component.parameters
+                                for param in area_resolved_template.component.parameters
                             ):
                                 self._iterate_through_model(
-                                    resolved_template,
+                                    area_resolved_template,
                                     components,
                                     connections,
                                     area_connections,
@@ -504,7 +511,7 @@ class AntaresStudyConverter:
                                 )
                         else:
                             self._iterate_through_model(
-                                resolved_template,
+                                area_resolved_template,
                                 components,
                                 connections,
                                 area_connections,

--- a/src/antares_gems_converter/input_converter/src/converter.py
+++ b/src/antares_gems_converter/input_converter/src/converter.py
@@ -481,7 +481,6 @@ class AntaresStudyConverter:
                                 area, TEMPLATE_CLUSTER_TYPE_TO_GET_METHOD[cluster_type]
                             )():
                                 # We have already resolved areas, now need to resolve cluster ids
-                                # Resolve from the area-resolved template, not from the previous cluster-resolved template
                                 cluster_resolved_template = (
                                     area_resolved_template.resolve_template(
                                         f"${{{cluster_type}}}", cluster_id


### PR DESCRIPTION
## Summary
This PR fixes template resolution logic in the model-to-component conversion process and adds error handling for missing legacy objects during deletion (closes #10, bug reported by @CorentinJeanne)

## Key Changes
- **Template Resolution Fix**: Corrected variable naming and resolution chain in `_convert_model_to_component_list()` to properly track area-level and cluster-level template resolutions separately. Previously, cluster template resolution was overwriting the area-resolved template, causing incorrect template state to be used in subsequent iterations.
  - Renamed `resolved_template` to `area_resolved_template` for clarity
  - Introduced `cluster_resolved_template` for cluster-specific resolution
  - Ensured cluster resolution always starts from the area-resolved template, not from a previously cluster-resolved template

- **Error Handling**: Added `KeyError` exception handling in `_delete_legacy_objects()` to gracefully handle cases where legacy components are not found in the study, logging a warning and continuing with deletion of other items.

## Implementation Details
The template resolution fix addresses a bug where the template resolution chain was not properly maintained. When iterating through clusters within areas, the code was reusing the same variable for both area and cluster resolution, causing the cluster resolution to be used as the base for the next area's processing. This change ensures each area starts with a fresh area-resolved template before resolving cluster-specific templates.
