### PR TITLE
rename antares_historic.yml lib to antares_legacy_models.yml

### DIFF
--- a/src/antares_gems_converter/input_converter/data/model_configuration/link.yaml
+++ b/src/antares_gems_converter/input_converter/data/model_configuration/link.yaml
@@ -14,7 +14,7 @@
 template:
   name: link
   generator-version-compatibility: X.Y #TODO: find this information
-  model: antares-historic.link
+  model: antares_legacy_models.link
   template-parameters:
     - name: link
       # exclude:

--- a/src/antares_gems_converter/input_converter/data/model_configuration/load.yaml
+++ b/src/antares_gems_converter/input_converter/data/model_configuration/load.yaml
@@ -14,7 +14,7 @@
 template:
   name: load
   generator-version-compatibility: X.Y #TODO: find this information
-  model: antares-historic.load
+  model: antares_legacy_models.load
   template-parameters:
     - name: area
       description: "Area identifier for the load component"

--- a/src/antares_gems_converter/input_converter/data/model_configuration/solar.yaml
+++ b/src/antares_gems_converter/input_converter/data/model_configuration/solar.yaml
@@ -14,7 +14,7 @@
 template:
   name: solar
   generator-version-compatibility: X.Y #TODO: find this information
-  model: antares-historic.renewable
+  model: antares_legacy_models.renewable
   template-parameters:
     - name: area
       description: "Area identifier for the solar component"

--- a/src/antares_gems_converter/input_converter/data/model_configuration/st-storage.yaml
+++ b/src/antares_gems_converter/input_converter/data/model_configuration/st-storage.yaml
@@ -14,7 +14,7 @@
 template:
   name: st_storage
   generator-version-compatibility: X.Y #TODO: find this information
-  model: antares-historic.short-term-storage
+  model: antares_legacy_models.short-term-storage
   template-parameters:
     - name: area
       cluster-type: st_storage

--- a/src/antares_gems_converter/input_converter/data/model_configuration/thermal.yaml
+++ b/src/antares_gems_converter/input_converter/data/model_configuration/thermal.yaml
@@ -14,7 +14,7 @@
 template:
   name: thermal
   generator-version-compatibility: X.Y #TODO: find this information
-  model: antares-historic.thermal
+  model: antares_legacy_models.thermal
   template-parameters:
     - name: area
       cluster-type: thermal

--- a/src/antares_gems_converter/input_converter/data/model_configuration/wind.yaml
+++ b/src/antares_gems_converter/input_converter/data/model_configuration/wind.yaml
@@ -14,7 +14,7 @@
 template:
   name: wind
   generator-version-compatibility: X.Y #TODO: find this information
-  model: antares-historic.renewable
+  model: antares_legacy_models.renewable
   scenario-group: wind_group
   template-parameters:
     - name: area

--- a/src/antares_gems_converter/input_converter/src/converter.py
+++ b/src/antares_gems_converter/input_converter/src/converter.py
@@ -57,7 +57,7 @@ from gems.study.parsing import (
     InputSystem,
 )
 
-ANTARES_HISTORIC_LIB_ID = "antares-historic"
+ANTARES_HISTORIC_LIB_ID = "antares_legacy_models"
 MODEL_TEMPLATE_FOLDER = Path(__file__).parents[1] / "data" / "model_configuration"
 LIBS_FOLDER = "model-libraries"
 SERIES_FOLDER = "data-series"

--- a/src/antares_gems_converter/libs/antares_historic/antares_legacy_models.yml
+++ b/src/antares_gems_converter/libs/antares_historic/antares_legacy_models.yml
@@ -10,7 +10,7 @@
 #
 # This file is part of the Antares project.
 library:
-  id: antares-historic
+  id: antares_legacy_models
   description: Antares historic model library
 
 

--- a/tests/antares_historic/utils.py
+++ b/tests/antares_historic/utils.py
@@ -16,7 +16,7 @@ from antares_gems_converter.input_converter.src.logger import Logger
 
 ANTARES_VERSION_CREATED_STUDIES = "9.2"
 ANTARES_LEGACY_MODELS_PATH = [
-    Path("src/antares_gems_converter/libs/antares_historic/antares_historic.yml")
+    Path("src/antares_gems_converter/libs/antares_historic/antares_legacy_models.yml")
 ]
 ACCURATE_TEMPLATE_PATH = Path(
     "tests/antares_historic/antares-resources/hybrid_mode_addon/uc_accurate"

--- a/tests/input_converter/conftest.py
+++ b/tests/input_converter/conftest.py
@@ -25,7 +25,7 @@ from antares.craft.model.thermal import ThermalClusterProperties
 
 @pytest.fixture
 def lib_id() -> str:
-    return "antares-historic"
+    return "antares_legacy_models"
 
 
 @pytest.fixture

--- a/tests/input_converter/resources/mini_test_BP_conversion/reference.yaml
+++ b/tests/input_converter/resources/mini_test_BP_conversion/reference.yaml
@@ -44,14 +44,14 @@ system:
           time-dependent: true
           value: marginal_cost_fr_z_batteries
     - id: load_fr
-      model: antares-historic.load
+      model: antares_legacy_models.load
       parameters:
         - id: load
           scenario-dependent: true
           time-dependent: true
           value: load_fr
     - id: fr_fr_nuclear_epr
-      model: antares-historic.thermal
+      model: antares_legacy_models.thermal
       parameters:
         - id: p_min_cluster
           scenario-dependent: true
@@ -98,7 +98,7 @@ system:
           time-dependent: true
           value: fr_fr_nuclear_epr_p_max_cluster
     - id: fr
-      model: antares-historic.area
+      model: antares_legacy_models.area
       parameters:
         - id: ens_cost
           scenario-dependent: false

--- a/tests/input_converter/resources/mini_test_batterie_BP23/reference.yaml
+++ b/tests/input_converter/resources/mini_test_batterie_BP23/reference.yaml
@@ -44,14 +44,14 @@ system:
           time-dependent: true
           value: marginal_cost_fr_z_batteries
     - id: load_fr
-      model: antares-historic.load
+      model: antares_legacy_models.load
       parameters:
         - id: load
           scenario-dependent: true
           time-dependent: true
           value: load_fr
     - id: fr_fr_nuclear_epr
-      model: antares-historic.thermal
+      model: antares_legacy_models.thermal
       parameters:
         - id: p_min_cluster
           scenario-dependent: true
@@ -98,7 +98,7 @@ system:
           time-dependent: true
           value: fr_fr_nuclear_epr_p_max_cluster
     - id: fr
-      model: antares-historic.area
+      model: antares_legacy_models.area
       parameters:
         - id: ens_cost
           scenario-dependent: false

--- a/tests/input_converter/test_converter.py
+++ b/tests/input_converter/test_converter.py
@@ -62,7 +62,7 @@ DATAFRAME_PREPRO_BC_CONFIG = (
     create_dataframe_from_constant(lines=8760, columns=4),  # series
 )
 LIB_PATHS = [
-    "src/antares_gems_converter/libs/antares_historic/antares_historic.yml",
+    "src/antares_gems_converter/libs/antares_historic/antares_legacy_models.yml",
     "src/antares_gems_converter/libs/reference_models/andromede_v1_models.yml",
 ]
 MODEL_LIST_WITH_BASE = [str(Path(os.getcwd()) / suffix) for suffix in LIB_PATHS]
@@ -114,7 +114,7 @@ class TestConverter:
             components=[
                 InputComponent(
                     id="fr",
-                    model="antares-historic.area",
+                    model="antares_legacy_models.area",
                     scenario_group=None,
                     parameters=[
                         InputComponentParameter(
@@ -135,7 +135,7 @@ class TestConverter:
                 ),
                 InputComponent(
                     id="it",
-                    model="antares-historic.area",
+                    model="antares_legacy_models.area",
                     scenario_group=None,
                     parameters=[
                         InputComponentParameter(
@@ -165,7 +165,7 @@ class TestConverter:
         expected_area_components = [
             InputComponent(
                 id="fr",
-                model="antares-historic.area",
+                model="antares_legacy_models.area",
                 parameters=[
                     InputComponentParameter(
                         id="ens_cost",
@@ -185,7 +185,7 @@ class TestConverter:
             ),
             InputComponent(
                 id="it",
-                model="antares-historic.area",
+                model="antares_legacy_models.area",
                 parameters=[
                     InputComponentParameter(
                         id="ens_cost",
@@ -224,7 +224,7 @@ class TestConverter:
             components=[
                 InputComponent(
                     id="it",
-                    model="antares-historic.area",
+                    model="antares_legacy_models.area",
                     scenario_group=None,
                     parameters=[
                         InputComponentParameter(
@@ -245,7 +245,7 @@ class TestConverter:
                 ),
                 InputComponent(
                     id="fr",
-                    model="antares-historic.area",
+                    model="antares_legacy_models.area",
                     scenario_group=None,
                     parameters=[
                         InputComponentParameter(
@@ -430,7 +430,7 @@ class TestConverter:
         expected_thermals_components = [
             InputComponent(
                 id="fr_gaz",
-                model="antares-historic.thermal",
+                model="antares_legacy_models.thermal",
                 scenario_group=None,
                 parameters=[
                     InputComponentParameter(
@@ -626,7 +626,7 @@ class TestConverter:
 
         expected_solar_components = InputComponent(
             id="solar_fr",
-            model="antares-historic.renewable",
+            model="antares_legacy_models.renewable",
             scenario_group=None,
             parameters=[
                 InputComponentParameter(
@@ -683,7 +683,7 @@ class TestConverter:
         )
         expected_load_components = InputComponent(
             id="load_fr",
-            model="antares-historic.load",
+            model="antares_legacy_models.load",
             scenario_group=None,
             parameters=[
                 InputComponentParameter(
@@ -731,7 +731,7 @@ class TestConverter:
         )
         expected_wind_components = InputComponent(
             id="wind_fr",
-            model="antares-historic.renewable",
+            model="antares_legacy_models.renewable",
             scenario_group="wind_group",
             parameters=[
                 InputComponentParameter(
@@ -833,7 +833,7 @@ class TestConverter:
         expected_link_component = [
             InputComponent(
                 id="fr_/_it",
-                model="antares-historic.link",
+                model="antares_legacy_models.link",
                 scenario_group=None,
                 parameters=[
                     InputComponentParameter(
@@ -868,7 +868,7 @@ class TestConverter:
             ),
             InputComponent(
                 id="at_/_fr",
-                model="antares-historic.link",
+                model="antares_legacy_models.link",
                 scenario_group=None,
                 parameters=[
                     InputComponentParameter(
@@ -903,7 +903,7 @@ class TestConverter:
             ),
             InputComponent(
                 id="at_/_it",
-                model="antares-historic.link",
+                model="antares_legacy_models.link",
                 scenario_group=None,
                 parameters=[
                     InputComponentParameter(

--- a/tests/input_converter/test_converter_modeler_scenariobuilder.py
+++ b/tests/input_converter/test_converter_modeler_scenariobuilder.py
@@ -20,7 +20,7 @@ class TestAntaresStudyConverterReal:
     @pytest.fixture
     def library_file(self):
         return Path(
-            "src/antares_gems_converter/libs/antares_historic/antares_historic.yml"
+            "src/antares_gems_converter/libs/antares_historic/antares_legacy_models.yml"
         )
 
     @pytest.fixture

--- a/tests/input_converter/test_thermal_prepro.py
+++ b/tests/input_converter/test_thermal_prepro.py
@@ -31,7 +31,7 @@ DATAFRAME_PREPRO_THERMAL_CONFIG = (
     create_dataframe_from_constant(lines=8760, columns=1, value=6),  # series
 )
 LIB_PATHS = [
-    "src/antares_gems_converter/libs/antares_historic/antares_historic.yml",
+    "src/antares_gems_converter/libs/antares_historic/antares_legacy_models.yml",
     "src/antares_gems_converter/libs/reference_models/andromede_v1_models.yml",
 ]
 LIB_PATHS_WITH_BASE = [str(Path(os.getcwd()) / suffix) for suffix in LIB_PATHS]


### PR DESCRIPTION
Renames the library file and updates its internal id from "antares-historic" to "antares_legacy_models". All references across model configuration templates, converter source code, and test files are updated accordingly.

