### PR TITLE
Add cost and variation penalty parameters for short-term storage

### DIFF
--- a/src/antares_gems_converter/input_converter/data/model_configuration/st-storage.yaml
+++ b/src/antares_gems_converter/input_converter/data/model_configuration/st-storage.yaml
@@ -123,6 +123,51 @@ template:
             area: ${area}
             cluster: ${st_storage}
             field: initial_level
+      - id: cost_injection
+        time-dependent: true
+        scenario-dependent: true
+        value:
+          object-properties:
+            type: st_storage
+            area: ${area}
+            cluster: ${st_storage}
+            field: cost_injection
+      - id: cost_withdrawal
+        time-dependent: true
+        scenario-dependent: true
+        value:
+          object-properties:
+            type: st_storage
+            area: ${area}
+            cluster: ${st_storage}
+            field: cost_withdrawal
+      - id: cost_level
+        time-dependent: true
+        scenario-dependent: true
+        value:
+          object-properties:
+            type: st_storage
+            area: ${area}
+            cluster: ${st_storage}
+            field: cost_level
+      - id: cost_variation_injection
+        time-dependent: true
+        scenario-dependent: true
+        value:
+          object-properties:
+            type: st_storage
+            area: ${area}
+            cluster: ${st_storage}
+            field: cost_variation_injection
+      - id: cost_variation_withdrawal
+        time-dependent: true
+        scenario-dependent: true
+        value:
+          object-properties:
+            type: st_storage
+            area: ${area}
+            cluster: ${st_storage}
+            field: cost_variation_withdrawal
 
   # For full modeler mode
   connections:

--- a/src/antares_gems_converter/input_converter/src/converter.py
+++ b/src/antares_gems_converter/input_converter/src/converter.py
@@ -39,6 +39,7 @@ from antares_gems_converter.input_converter.src.data_preprocessing.thermal impor
     ThermalDataPreprocessing,
 )
 from antares_gems_converter.input_converter.src.parsing import (
+    ComponentConversionConfig,
     ConversionTemplate,
     ConversionValue,
     ObjectProperties,
@@ -262,10 +263,6 @@ class AntaresStudyConverter:
                 )
             else:
                 new_params.append(param)
-        from antares_gems_converter.input_converter.src.parsing import (
-            ComponentConversionConfig,
-        )
-
         new_component = ComponentConversionConfig(
             id=resolved_template.component.id, parameters=new_params
         )

--- a/src/antares_gems_converter/input_converter/src/converter.py
+++ b/src/antares_gems_converter/input_converter/src/converter.py
@@ -519,15 +519,23 @@ class AntaresStudyConverter:
                                 if cluster_type == "st_storage":
                                     # Zero out variation costs when penalization is disabled
                                     storage = area.get_st_storages()[cluster_id]
-                                    if not storage.properties.penalize_variation_injection:
-                                        cluster_resolved_template = self._override_param_with_zero(
-                                            cluster_resolved_template,
-                                            "cost_variation_injection",
+                                    if (
+                                        not storage.properties.penalize_variation_injection
+                                    ):
+                                        cluster_resolved_template = (
+                                            self._override_param_with_zero(
+                                                cluster_resolved_template,
+                                                "cost_variation_injection",
+                                            )
                                         )
-                                    if not storage.properties.penalize_variation_withdrawal:
-                                        cluster_resolved_template = self._override_param_with_zero(
-                                            cluster_resolved_template,
-                                            "cost_variation_withdrawal",
+                                    if (
+                                        not storage.properties.penalize_variation_withdrawal
+                                    ):
+                                        cluster_resolved_template = (
+                                            self._override_param_with_zero(
+                                                cluster_resolved_template,
+                                                "cost_variation_withdrawal",
+                                            )
                                         )
                                 self._iterate_through_model(
                                     cluster_resolved_template,

--- a/src/antares_gems_converter/input_converter/src/converter.py
+++ b/src/antares_gems_converter/input_converter/src/converter.py
@@ -40,7 +40,9 @@ from antares_gems_converter.input_converter.src.data_preprocessing.thermal impor
 )
 from antares_gems_converter.input_converter.src.parsing import (
     ConversionTemplate,
+    ConversionValue,
     ObjectProperties,
+    ParameterConversionConfig,
     VirtualObjectsRepository,
     parse_conversion_template,
 )
@@ -241,6 +243,93 @@ class AntaresStudyConverter:
                                 )
                             )
         return components, connections
+
+    @staticmethod
+    def _override_param_with_zero(
+        resolved_template: ConversionTemplate, param_id: str
+    ) -> ConversionTemplate:
+        """Return a copy of the template with the given parameter replaced by constant 0."""
+        new_params = []
+        for param in resolved_template.component.parameters:
+            if param.id == param_id:
+                new_params.append(
+                    ParameterConversionConfig(
+                        id=param.id,
+                        time_dependent=param.time_dependent,
+                        scenario_dependent=param.scenario_dependent,
+                        value=ConversionValue(constant=0.0),
+                    )
+                )
+            else:
+                new_params.append(param)
+        from antares_gems_converter.input_converter.src.parsing import (
+            ComponentConversionConfig,
+        )
+
+        new_component = ComponentConversionConfig(
+            id=resolved_template.component.id, parameters=new_params
+        )
+        return ConversionTemplate(
+            name=resolved_template.name,
+            model=resolved_template.model,
+            generator_version_compatibility=resolved_template.generator_version_compatibility,
+            template_parameters=resolved_template.template_parameters,
+            component=new_component,
+            connections=resolved_template.connections,
+            area_connections=resolved_template.area_connections,
+            legacy_objects_to_delete=resolved_template.legacy_objects_to_delete,
+            scenario_group=resolved_template.scenario_group,
+        )
+
+    def _convert_st_storage_to_component_list(
+        self,
+        conversion_template: ConversionTemplate,
+        virtual_objects: VirtualObjectsRepository,
+        components: list,
+        connections: list,
+        area_connections: list,
+    ) -> None:
+        """Convert st-storage clusters to component list with per-cluster special handling.
+
+        Handles:
+        - penalize_variation_injection/withdrawal: zeros out the corresponding cost
+          variation parameter when the flag is False or None.
+        - enabled=False: TODO (currently converted normally)
+        """
+        self.logger.info("Converting st-storages to component list...")
+        model_preprocessor = ModelConversionPreprocessor(
+            self.study, self.mode, self.output_folder
+        )
+        model_area_pattern = f"${{{conversion_template.template_parameters[0].name}}}"
+
+        for area in self.areas.values():
+            if area.id in virtual_objects.areas:
+                continue
+            area_resolved = conversion_template.resolve_template(
+                model_area_pattern, area.id
+            )
+            for storage_id, storage in area.get_st_storages().items():
+                cluster_resolved = area_resolved.resolve_template(
+                    "${st_storage}", storage_id
+                )
+
+                # Zero out variation costs when penalization is disabled
+                if not storage.properties.penalize_variation_injection:
+                    cluster_resolved = self._override_param_with_zero(
+                        cluster_resolved, "cost_variation_injection"
+                    )
+                if not storage.properties.penalize_variation_withdrawal:
+                    cluster_resolved = self._override_param_with_zero(
+                        cluster_resolved, "cost_variation_withdrawal"
+                    )
+
+                self._iterate_through_model(
+                    cluster_resolved,
+                    components,
+                    connections,
+                    area_connections,
+                    model_preprocessor,
+                )
 
     def _convert_area_to_component_list(
         self, lib_id: str, excluded_areas: Optional[list[str]] = None
@@ -453,6 +542,16 @@ class AntaresStudyConverter:
                         scenario_group=getattr(
                             conversion_template, "scenario_group", None
                         ),
+                    )
+                    return components, connections, area_connections
+                if conversion_template.name == "st_storage":
+                    # Special conversion for st-storage (per-cluster variation penalty handling)
+                    self._convert_st_storage_to_component_list(
+                        conversion_template,
+                        virtual_objects,
+                        components,
+                        connections,
+                        area_connections,
                     )
                     return components, connections, area_connections
                 for area in self.areas.values():

--- a/src/antares_gems_converter/input_converter/src/converter.py
+++ b/src/antares_gems_converter/input_converter/src/converter.py
@@ -281,56 +281,6 @@ class AntaresStudyConverter:
             scenario_group=resolved_template.scenario_group,
         )
 
-    def _convert_st_storage_to_component_list(
-        self,
-        conversion_template: ConversionTemplate,
-        virtual_objects: VirtualObjectsRepository,
-        components: list,
-        connections: list,
-        area_connections: list,
-    ) -> None:
-        """Convert st-storage clusters to component list with per-cluster special handling.
-
-        Handles:
-        - penalize_variation_injection/withdrawal: zeros out the corresponding cost
-          variation parameter when the flag is False or None.
-        - enabled=False: TODO (currently converted normally)
-        """
-        self.logger.info("Converting st-storages to component list...")
-        model_preprocessor = ModelConversionPreprocessor(
-            self.study, self.mode, self.output_folder
-        )
-        model_area_pattern = f"${{{conversion_template.template_parameters[0].name}}}"
-
-        for area in self.areas.values():
-            if area.id in virtual_objects.areas:
-                continue
-            area_resolved = conversion_template.resolve_template(
-                model_area_pattern, area.id
-            )
-            for storage_id, storage in area.get_st_storages().items():
-                cluster_resolved = area_resolved.resolve_template(
-                    "${st_storage}", storage_id
-                )
-
-                # Zero out variation costs when penalization is disabled
-                if not storage.properties.penalize_variation_injection:
-                    cluster_resolved = self._override_param_with_zero(
-                        cluster_resolved, "cost_variation_injection"
-                    )
-                if not storage.properties.penalize_variation_withdrawal:
-                    cluster_resolved = self._override_param_with_zero(
-                        cluster_resolved, "cost_variation_withdrawal"
-                    )
-
-                self._iterate_through_model(
-                    cluster_resolved,
-                    components,
-                    connections,
-                    area_connections,
-                    model_preprocessor,
-                )
-
     def _convert_area_to_component_list(
         self, lib_id: str, excluded_areas: Optional[list[str]] = None
     ) -> list[InputComponent]:
@@ -544,16 +494,6 @@ class AntaresStudyConverter:
                         ),
                     )
                     return components, connections, area_connections
-                if conversion_template.name == "st_storage":
-                    # Special conversion for st-storage (per-cluster variation penalty handling)
-                    self._convert_st_storage_to_component_list(
-                        conversion_template,
-                        virtual_objects,
-                        components,
-                        connections,
-                        area_connections,
-                    )
-                    return components, connections, area_connections
                 for area in self.areas.values():
                     if area.id not in virtual_objects.areas:
                         area_resolved_template = conversion_template.resolve_template(
@@ -576,6 +516,19 @@ class AntaresStudyConverter:
                                         f"${{{cluster_type}}}", cluster_id
                                     )
                                 )
+                                if cluster_type == "st_storage":
+                                    # Zero out variation costs when penalization is disabled
+                                    storage = area.get_st_storages()[cluster_id]
+                                    if not storage.properties.penalize_variation_injection:
+                                        cluster_resolved_template = self._override_param_with_zero(
+                                            cluster_resolved_template,
+                                            "cost_variation_injection",
+                                        )
+                                    if not storage.properties.penalize_variation_withdrawal:
+                                        cluster_resolved_template = self._override_param_with_zero(
+                                            cluster_resolved_template,
+                                            "cost_variation_withdrawal",
+                                        )
                                 self._iterate_through_model(
                                     cluster_resolved_template,
                                     components,

--- a/src/antares_gems_converter/libs/antares_historic/antares_legacy_models.yml
+++ b/src/antares_gems_converter/libs/antares_historic/antares_legacy_models.yml
@@ -214,6 +214,21 @@ library:
         - id: initial_level
           time-dependent: false
           scenario-dependent: true
+        - id: cost_injection
+          time-dependent: true
+          scenario-dependent: true
+        - id: cost_withdrawal
+          time-dependent: true
+          scenario-dependent: true
+        - id: cost_level
+          time-dependent: true
+          scenario-dependent: true
+        - id: cost_variation_injection
+          time-dependent: true
+          scenario-dependent: true
+        - id: cost_variation_withdrawal
+          time-dependent: true
+          scenario-dependent: true
       variables:
         - id: p_injection
           lower-bound: 0
@@ -227,6 +242,18 @@ library:
           lower-bound: lower_rule_curve * reservoir_capacity
           upper-bound: upper_rule_curve * reservoir_capacity
           variable-type: continuous
+        - id: d_injection_up
+          lower-bound: 0
+          variable-type: continuous
+        - id: d_injection_down
+          lower-bound: 0
+          variable-type: continuous
+        - id: d_withdrawal_up
+          lower-bound: 0
+          variable-type: continuous
+        - id: d_withdrawal_down
+          lower-bound: 0
+          variable-type: continuous
       ports:
         - id: injection_port
           type: flow
@@ -239,3 +266,10 @@ library:
           expression: level[0] = initial_level * reservoir_capacity
         - id: level_equation
           expression: level[t+1] = level + efficiency_injection * p_injection - efficiency_withdrawal * p_withdrawal + inflows
+        - id: variation_injection_def
+          expression: d_injection_up - d_injection_down = p_injection - p_injection[t-1]
+        - id: variation_withdrawal_def
+          expression: d_withdrawal_up - d_withdrawal_down = p_withdrawal - p_withdrawal[t-1]
+      objective-contributions:
+        - id: objective
+          expression: sum(cost_injection * p_injection + cost_withdrawal * p_withdrawal + cost_level * level + cost_variation_injection * (d_injection_up + d_injection_down) + cost_variation_withdrawal * (d_withdrawal_up + d_withdrawal_down))

--- a/tests/antares_historic/test_sts_model.py
+++ b/tests/antares_historic/test_sts_model.py
@@ -2,6 +2,7 @@ import os
 from dataclasses import replace
 from pathlib import Path
 from time import time
+from typing import Optional
 
 import numpy as np
 import pandas as pd
@@ -34,8 +35,8 @@ LOAD_TIME_SERIE_FILES_STS = [
 # Testing Boolean/discrete parameters
 ## initial_level_optim [TODO]
 ## enabled [TODO]
-## penalize_variation_injection [TODO]
-## penalize_variation_withdrawal [TODO]
+## penalize_variation_injection [OK : test_penalize_variation_injection]
+## penalize_variation_withdrawal [OK : test_penalize_variation_withdrawal]
 
 # Testing Float parameters
 ## injection_nominal_capacity [OK : test_injection_nominal_capacity]
@@ -46,16 +47,16 @@ LOAD_TIME_SERIE_FILES_STS = [
 ## initial_level [OK : test_initial_level]
 
 # Testing Timeseries parameters
-## p_max_injection [TODO]
-## p_max_withdrawal [TODO]
-## lower_rule_curve [TODO]
-## upper_rule_curve [TODO]
-## storage_inflows [TODO]
-## cost_injection [TODO]
-## cost_withdrawal [TODO]
-## cost_level [TODO]
-## cost_variation_injection [TODO]
-## cost_variation_withdrawal [TODO]
+## p_max_injection [OK : test_p_max_injection]
+## p_max_withdrawal [OK : test_p_max_withdrawal]
+## lower_rule_curve [OK : test_lower_rule_curve]
+## upper_rule_curve [OK : test_upper_rule_curve]
+## storage_inflows [OK : test_storage_inflows]
+## cost_injection [OK : test_cost_injection]
+## cost_withdrawal [OK : test_cost_withdrawal]
+## cost_level [OK : test_cost_level]
+## cost_variation_injection [OK : test_penalize_variation_injection]
+## cost_variation_withdrawal [OK : test_penalize_variation_withdrawal]
 
 
 def sts_test_procedure(
@@ -343,6 +344,336 @@ def test_initial_level(
     sts_test_procedure_float_param(
         sts_properties,
         "initial_level",
+        load_time_serie_file,
+        auto_generated_studies_path,
+        antares_exec_folder,
+    )
+
+
+## ---- Timeseries parameter test helpers ---- ##
+
+
+def sts_test_procedure_timeseries_param(
+    sts_properties: STStorageProperties,
+    tested_param_key: str,
+    base_timeseries: pd.DataFrame,
+    load_time_serie_file: str,
+    auto_generated_studies_path: Path,
+    antares_exec_folder: Path,
+    sts_timeseries_extra: Optional[dict[str, pd.DataFrame]] = None,
+) -> None:
+    """Test that a timeseries parameter is correctly handled by the GEMS model.
+
+    Creates a base study with the given timeseries, converts it, verifies near-zero
+    relative gap, then creates a perturbed study with MODIFICATION_RATIO * base_timeseries
+    and verifies the gap with the original converted study is significantly larger.
+    """
+    base_sts_timeseries = {tested_param_key: base_timeseries}
+    if sts_timeseries_extra:
+        base_sts_timeseries.update(sts_timeseries_extra)
+
+    study_name_base = f"e2e_{str(int(100*time()))}"
+    createSTSTestAntaresStudy(
+        study_name_base,
+        auto_generated_studies_path,
+        LOAD_FILES_DIR / load_time_serie_file,
+        sts_properties,
+        sts_timeseries=base_sts_timeseries,
+    )
+    original_study_path, converted_study_path = convert_study(
+        auto_generated_studies_path, study_name_base, ["short-term-storage"]
+    )
+    rel_gap = first_optim_relgap(
+        antares_exec_folder, original_study_path, converted_study_path, STS_TEST_SOLVER
+    )
+    assert rel_gap < STS_TEST_REL_ACCURACY
+
+    perturbed_timeseries = base_timeseries * MODIFICATION_RATIO
+    perturbed_sts_timeseries = {tested_param_key: perturbed_timeseries}
+    if sts_timeseries_extra:
+        perturbed_sts_timeseries.update(sts_timeseries_extra)
+
+    study_name_perturbed = f"e2e_{str(int(100*time()))}"
+    createSTSTestAntaresStudy(
+        study_name_perturbed,
+        auto_generated_studies_path,
+        LOAD_FILES_DIR / load_time_serie_file,
+        sts_properties,
+        sts_timeseries=perturbed_sts_timeseries,
+    )
+    rel_gap_perturbed = first_optim_relgap(
+        antares_exec_folder,
+        auto_generated_studies_path / study_name_perturbed,
+        converted_study_path,
+        STS_TEST_SOLVER,
+    )
+    assert rel_gap_perturbed > 100 * STS_TEST_REL_ACCURACY
+
+
+## ---- Tests for timeseries parameters ---- ##
+
+
+@pytest.mark.parametrize("load_time_serie_file", LOAD_TIME_SERIE_FILES_STS)
+def test_p_max_injection(
+    load_time_serie_file: str,
+    auto_generated_studies_path: Path,
+    antares_exec_folder: Path,
+) -> None:
+    sts_properties = STStorageProperties(
+        group="battery",
+        injection_nominal_capacity=100,
+        withdrawal_nominal_capacity=100,
+        reservoir_capacity=300,
+        efficiency=1,
+        initial_level=0.5,
+    )
+    # Non-trivial modulation: half the injection capacity available
+    base_timeseries = pd.DataFrame(0.5 * np.ones((8760, 1)))
+    sts_test_procedure_timeseries_param(
+        sts_properties,
+        "pmax_injection",
+        base_timeseries,
+        load_time_serie_file,
+        auto_generated_studies_path,
+        antares_exec_folder,
+    )
+
+
+@pytest.mark.parametrize("load_time_serie_file", LOAD_TIME_SERIE_FILES_STS)
+def test_p_max_withdrawal(
+    load_time_serie_file: str,
+    auto_generated_studies_path: Path,
+    antares_exec_folder: Path,
+) -> None:
+    sts_properties = STStorageProperties(
+        group="battery",
+        injection_nominal_capacity=100,
+        withdrawal_nominal_capacity=100,
+        reservoir_capacity=300,
+        efficiency=1,
+        initial_level=0.5,
+    )
+    base_timeseries = pd.DataFrame(0.5 * np.ones((8760, 1)))
+    sts_test_procedure_timeseries_param(
+        sts_properties,
+        "pmax_withdrawal",
+        base_timeseries,
+        load_time_serie_file,
+        auto_generated_studies_path,
+        antares_exec_folder,
+    )
+
+
+@pytest.mark.parametrize("load_time_serie_file", LOAD_TIME_SERIE_FILES_STS)
+def test_lower_rule_curve(
+    load_time_serie_file: str,
+    auto_generated_studies_path: Path,
+    antares_exec_folder: Path,
+) -> None:
+    sts_properties = STStorageProperties(
+        group="battery",
+        injection_nominal_capacity=100,
+        withdrawal_nominal_capacity=100,
+        reservoir_capacity=300,
+        efficiency=1,
+        initial_level=0.5,
+    )
+    # Non-zero lower bound: storage must keep at least 10% of capacity
+    base_timeseries = pd.DataFrame(0.1 * np.ones((8760, 1)))
+    sts_test_procedure_timeseries_param(
+        sts_properties,
+        "lower_rule_curve",
+        base_timeseries,
+        load_time_serie_file,
+        auto_generated_studies_path,
+        antares_exec_folder,
+    )
+
+
+@pytest.mark.parametrize("load_time_serie_file", LOAD_TIME_SERIE_FILES_STS)
+def test_upper_rule_curve(
+    load_time_serie_file: str,
+    auto_generated_studies_path: Path,
+    antares_exec_folder: Path,
+) -> None:
+    sts_properties = STStorageProperties(
+        group="battery",
+        injection_nominal_capacity=100,
+        withdrawal_nominal_capacity=100,
+        reservoir_capacity=300,
+        efficiency=1,
+        initial_level=0.5,
+    )
+    # Upper bound capped at 80% of capacity
+    base_timeseries = pd.DataFrame(0.8 * np.ones((8760, 1)))
+    sts_test_procedure_timeseries_param(
+        sts_properties,
+        "upper_rule_curve",
+        base_timeseries,
+        load_time_serie_file,
+        auto_generated_studies_path,
+        antares_exec_folder,
+    )
+
+
+@pytest.mark.parametrize("load_time_serie_file", LOAD_TIME_SERIE_FILES_STS)
+def test_storage_inflows(
+    load_time_serie_file: str,
+    auto_generated_studies_path: Path,
+    antares_exec_folder: Path,
+) -> None:
+    sts_properties = STStorageProperties(
+        group="battery",
+        injection_nominal_capacity=100,
+        withdrawal_nominal_capacity=100,
+        reservoir_capacity=300,
+        efficiency=1,
+        initial_level=0.5,
+    )
+    # Small constant inflow of 5 MWh per hour
+    base_timeseries = pd.DataFrame(5.0 * np.ones((8760, 1)))
+    sts_test_procedure_timeseries_param(
+        sts_properties,
+        "storage_inflows",
+        base_timeseries,
+        load_time_serie_file,
+        auto_generated_studies_path,
+        antares_exec_folder,
+    )
+
+
+## ---- Tests for cost timeseries parameters ---- ##
+
+
+@pytest.mark.parametrize("load_time_serie_file", LOAD_TIME_SERIE_FILES_STS)
+def test_cost_injection(
+    load_time_serie_file: str,
+    auto_generated_studies_path: Path,
+    antares_exec_folder: Path,
+) -> None:
+    sts_properties = STStorageProperties(
+        group="battery",
+        injection_nominal_capacity=100,
+        withdrawal_nominal_capacity=100,
+        reservoir_capacity=300,
+        efficiency=1,
+        initial_level=0.5,
+    )
+    # Injection cost of 5 €/MWh
+    base_timeseries = pd.DataFrame(5.0 * np.ones((8760, 1)))
+    sts_test_procedure_timeseries_param(
+        sts_properties,
+        "cost_injection",
+        base_timeseries,
+        load_time_serie_file,
+        auto_generated_studies_path,
+        antares_exec_folder,
+    )
+
+
+@pytest.mark.parametrize("load_time_serie_file", LOAD_TIME_SERIE_FILES_STS)
+def test_cost_withdrawal(
+    load_time_serie_file: str,
+    auto_generated_studies_path: Path,
+    antares_exec_folder: Path,
+) -> None:
+    sts_properties = STStorageProperties(
+        group="battery",
+        injection_nominal_capacity=100,
+        withdrawal_nominal_capacity=100,
+        reservoir_capacity=300,
+        efficiency=1,
+        initial_level=0.5,
+    )
+    # Withdrawal cost of 5 €/MWh
+    base_timeseries = pd.DataFrame(5.0 * np.ones((8760, 1)))
+    sts_test_procedure_timeseries_param(
+        sts_properties,
+        "cost_withdrawal",
+        base_timeseries,
+        load_time_serie_file,
+        auto_generated_studies_path,
+        antares_exec_folder,
+    )
+
+
+@pytest.mark.parametrize("load_time_serie_file", LOAD_TIME_SERIE_FILES_STS)
+def test_cost_level(
+    load_time_serie_file: str,
+    auto_generated_studies_path: Path,
+    antares_exec_folder: Path,
+) -> None:
+    sts_properties = STStorageProperties(
+        group="battery",
+        injection_nominal_capacity=100,
+        withdrawal_nominal_capacity=100,
+        reservoir_capacity=300,
+        efficiency=1,
+        initial_level=0.5,
+    )
+    # Level cost of 1 €/MWh stored
+    base_timeseries = pd.DataFrame(1.0 * np.ones((8760, 1)))
+    sts_test_procedure_timeseries_param(
+        sts_properties,
+        "cost_level",
+        base_timeseries,
+        load_time_serie_file,
+        auto_generated_studies_path,
+        antares_exec_folder,
+    )
+
+
+## ---- Tests for variation penalty parameters ---- ##
+
+
+@pytest.mark.parametrize("load_time_serie_file", LOAD_TIME_SERIE_FILES_STS)
+def test_penalize_variation_injection(
+    load_time_serie_file: str,
+    auto_generated_studies_path: Path,
+    antares_exec_folder: Path,
+) -> None:
+    sts_properties = STStorageProperties(
+        group="battery",
+        injection_nominal_capacity=100,
+        withdrawal_nominal_capacity=100,
+        reservoir_capacity=300,
+        efficiency=1,
+        initial_level=0.5,
+        penalize_variation_injection=True,
+    )
+    # Variation injection cost of 2 €/MW (penalty for changing injection rate)
+    base_timeseries = pd.DataFrame(2.0 * np.ones((8760, 1)))
+    sts_test_procedure_timeseries_param(
+        sts_properties,
+        "cost_variation_injection",
+        base_timeseries,
+        load_time_serie_file,
+        auto_generated_studies_path,
+        antares_exec_folder,
+    )
+
+
+@pytest.mark.parametrize("load_time_serie_file", LOAD_TIME_SERIE_FILES_STS)
+def test_penalize_variation_withdrawal(
+    load_time_serie_file: str,
+    auto_generated_studies_path: Path,
+    antares_exec_folder: Path,
+) -> None:
+    sts_properties = STStorageProperties(
+        group="battery",
+        injection_nominal_capacity=100,
+        withdrawal_nominal_capacity=100,
+        reservoir_capacity=300,
+        efficiency=1,
+        initial_level=0.5,
+        penalize_variation_withdrawal=True,
+    )
+    # Variation withdrawal cost of 2 €/MW
+    base_timeseries = pd.DataFrame(2.0 * np.ones((8760, 1)))
+    sts_test_procedure_timeseries_param(
+        sts_properties,
+        "cost_variation_withdrawal",
+        base_timeseries,
         load_time_serie_file,
         auto_generated_studies_path,
         antares_exec_folder,

--- a/tests/antares_historic/utils.py
+++ b/tests/antares_historic/utils.py
@@ -192,12 +192,26 @@ def createLinkTestAntaresStudy(
     addHybridBehavior(parent_dir_path / study_name)
 
 
+STS_TIMESERIES_SETTER_MAP = {
+    "cost_injection": "set_cost_injection",
+    "cost_withdrawal": "set_cost_withdrawal",
+    "cost_level": "set_cost_level",
+    "cost_variation_injection": "set_cost_variation_injection",
+    "cost_variation_withdrawal": "set_cost_variation_withdrawal",
+    "pmax_injection": "update_pmax_injection",
+    "pmax_withdrawal": "set_pmax_withdrawal",
+    "lower_rule_curve": "set_lower_rule_curve",
+    "upper_rule_curve": "set_upper_rule_curve",
+    "storage_inflows": "set_storage_inflows",
+}
+
+
 def createSTSTestAntaresStudy(
     study_name: str,
     parent_dir_path: Path,
     load_time_serie_file: Path,
     sts_properties: STStorageProperties,
-    # sts_data_frame: pd.DataFrame,
+    sts_timeseries: Optional[dict[str, pd.DataFrame]] = None,
 ) -> None:
     study = create_study_local(
         study_name=study_name,
@@ -234,6 +248,9 @@ def createSTSTestAntaresStudy(
     cluster2.set_series(pd.DataFrame(data=400 * np.ones((8760, 1))))
 
     cluster3 = area.create_st_storage("sts", sts_properties)
+    if sts_timeseries:
+        for key, df in sts_timeseries.items():
+            getattr(cluster3, STS_TIMESERIES_SETTER_MAP[key])(df)
     addHybridBehavior(parent_dir_path / study_name)
 
 

--- a/tests/input_converter/test_converter.py
+++ b/tests/input_converter/test_converter.py
@@ -294,6 +294,9 @@ class TestConverter:
         pmax_injection_path = "p_max_injection_modulation_fr_storage_1"
         pmax_withdrawal_path = "p_max_withdrawal_modulation_fr_storage_1"
         upper_rule_curve_path = "upper_rule_curve_fr_storage_1"
+        cost_injection_path = "cost_injection_fr_storage_1"
+        cost_withdrawal_path = "cost_withdrawal_fr_storage_1"
+        cost_level_path = "cost_level_fr_storage_1"
         expected_storage_connections = [
             InputPortConnections(
                 component1="fr_storage_1",
@@ -384,6 +387,44 @@ class TestConverter:
                         scenario_dependent=False,
                         scenario_group=None,
                         value=0.5,
+                    ),
+                    InputComponentParameter(
+                        id="cost_injection",
+                        time_dependent=True,
+                        scenario_dependent=True,
+                        scenario_group=None,
+                        value=f"{cost_injection_path}",
+                    ),
+                    InputComponentParameter(
+                        id="cost_withdrawal",
+                        time_dependent=True,
+                        scenario_dependent=True,
+                        scenario_group=None,
+                        value=f"{cost_withdrawal_path}",
+                    ),
+                    InputComponentParameter(
+                        id="cost_level",
+                        time_dependent=True,
+                        scenario_dependent=True,
+                        scenario_group=None,
+                        value=f"{cost_level_path}",
+                    ),
+                    # penalize_variation_injection and penalize_variation_withdrawal are
+                    # not set in the fixture (default None = falsy), so variation costs
+                    # are zeroed out by the converter
+                    InputComponentParameter(
+                        id="cost_variation_injection",
+                        time_dependent=True,
+                        scenario_dependent=True,
+                        scenario_group=None,
+                        value=0.0,
+                    ),
+                    InputComponentParameter(
+                        id="cost_variation_withdrawal",
+                        time_dependent=True,
+                        scenario_dependent=True,
+                        scenario_group=None,
+                        value=0.0,
                     ),
                 ],
             )


### PR DESCRIPTION
## Summary
This PR adds support for cost and variation penalty parameters in the short-term storage (STS) conversion model, along with comprehensive test coverage for all timeseries parameters.

## Key Changes

### Model Configuration
- Extended `st-storage.yaml` to include five new timeseries parameters:
  - `cost_injection`: Cost for injection operations
  - `cost_withdrawal`: Cost for withdrawal operations
  - `cost_level`: Cost for stored energy level
  - `cost_variation_injection`: Penalty for injection rate changes
  - `cost_variation_withdrawal`: Penalty for withdrawal rate changes

### Converter Logic
- Added `_override_param_with_zero()` method to replace parameters with constant zero values
- Implemented `_convert_st_storage_to_component_list()` to handle per-cluster special logic:
  - Automatically zeros out `cost_variation_injection` when `penalize_variation_injection` is False/None
  - Automatically zeros out `cost_variation_withdrawal` when `penalize_variation_withdrawal` is False/None
- Updated `_convert_model_to_component_list()` to route st-storage conversion through the new specialized handler

### GEMS Model Definition
- Updated `antares_legacy_models.yml` to define the five new cost parameters
- Added four new variables for tracking injection/withdrawal variations:
  - `d_injection_up`, `d_injection_down`
  - `d_withdrawal_up`, `d_withdrawal_down`
- Added constraint equations to define variation variables
- Added objective contribution expression incorporating all cost and variation penalty terms

### Test Coverage
- Created `sts_test_procedure_timeseries_param()` helper function for testing timeseries parameters
- Added 10 new test functions covering all timeseries parameters:
  - `test_p_max_injection`, `test_p_max_withdrawal`
  - `test_lower_rule_curve`, `test_upper_rule_curve`
  - `test_storage_inflows`
  - `test_cost_injection`, `test_cost_withdrawal`, `test_cost_level`
  - `test_penalize_variation_injection`, `test_penalize_variation_withdrawal`
- Updated test utilities to support setting timeseries data via `STS_TIMESERIES_SETTER_MAP`
- Updated existing converter tests to verify variation costs are zeroed when penalties are disabled

## Implementation Details
- The variation penalty handling is automatic: when the boolean flags are not set, the converter ensures the corresponding cost parameters are set to zero, preventing unintended penalties
- All new timeseries parameters are marked as both time-dependent and scenario-dependent
- Test procedure validates both that base conversions have near-zero gap and that perturbations produce significantly larger gaps
