### PR TITLE
feat: add cost_injection, cost_withdrawal, cost_level to st-storage GEMS model + test 8 timeseries parameters

### DIFF
--- a/src/antares_gems_converter/input_converter/data/model_configuration/st-storage.yaml
+++ b/src/antares_gems_converter/input_converter/data/model_configuration/st-storage.yaml
@@ -123,6 +123,33 @@ template:
             area: ${area}
             cluster: ${st_storage}
             field: initial_level
+      - id: cost_injection
+        time-dependent: true
+        scenario-dependent: true
+        value:
+          object-properties:
+            type: st_storage
+            area: ${area}
+            cluster: ${st_storage}
+            field: cost_injection
+      - id: cost_withdrawal
+        time-dependent: true
+        scenario-dependent: true
+        value:
+          object-properties:
+            type: st_storage
+            area: ${area}
+            cluster: ${st_storage}
+            field: cost_withdrawal
+      - id: cost_level
+        time-dependent: true
+        scenario-dependent: true
+        value:
+          object-properties:
+            type: st_storage
+            area: ${area}
+            cluster: ${st_storage}
+            field: cost_level
 
   # For full modeler mode
   connections:

--- a/src/antares_gems_converter/libs/antares_historic/antares_legacy_models.yml
+++ b/src/antares_gems_converter/libs/antares_historic/antares_legacy_models.yml
@@ -215,6 +215,15 @@ library:
         - id: initial_level
           time-dependent: false
           scenario-dependent: true
+        - id: cost_injection
+          time-dependent: true
+          scenario-dependent: true
+        - id: cost_withdrawal
+          time-dependent: true
+          scenario-dependent: true
+        - id: cost_level
+          time-dependent: true
+          scenario-dependent: true
       variables:
         - id: p_injection
           lower-bound: 0
@@ -240,3 +249,6 @@ library:
           expression: level[0] = initial_level * reservoir_capacity
         - id: level_equation
           expression: level[t+1] = level + efficiency_injection * p_injection - efficiency_withdrawal * p_withdrawal + inflows
+      objective-contributions:
+        - id: objective
+          expression: sum(cost_injection * p_injection + cost_withdrawal * p_withdrawal + cost_level * level)

--- a/tests/antares_historic/test_sts_model.py
+++ b/tests/antares_historic/test_sts_model.py
@@ -2,6 +2,7 @@ import os
 from dataclasses import replace
 from pathlib import Path
 from time import time
+from typing import Optional
 
 import numpy as np
 import pandas as pd
@@ -10,6 +11,7 @@ from antares.craft import STStorageProperties
 
 from antares_gems_converter.input_converter.src.logger import Logger
 from tests.antares_historic.utils import (
+    STS_TIMESERIES_SETTER_MAP,
     convert_study,
     createSTSTestAntaresStudy,
     first_optim_relgap,
@@ -46,14 +48,14 @@ LOAD_TIME_SERIE_FILES_STS = [
 ## initial_level [OK : test_initial_level]
 
 # Testing Timeseries parameters
-## p_max_injection [TODO]
-## p_max_withdrawal [TODO]
-## lower_rule_curve [TODO]
-## upper_rule_curve [TODO]
-## storage_inflows [TODO]
-## cost_injection [TODO]
-## cost_withdrawal [TODO]
-## cost_level [TODO]
+## p_max_injection [OK : test_p_max_injection]
+## p_max_withdrawal [OK : test_p_max_withdrawal]
+## lower_rule_curve [OK : test_lower_rule_curve]
+## upper_rule_curve [OK : test_upper_rule_curve]
+## storage_inflows [OK : test_storage_inflows]
+## cost_injection [OK : test_cost_injection]
+## cost_withdrawal [OK : test_cost_withdrawal]
+## cost_level [OK : test_cost_level]
 ## cost_variation_injection [TODO]
 ## cost_variation_withdrawal [TODO]
 
@@ -343,6 +345,272 @@ def test_initial_level(
     sts_test_procedure_float_param(
         sts_properties,
         "initial_level",
+        load_time_serie_file,
+        auto_generated_studies_path,
+        antares_exec_folder,
+    )
+
+
+## ---- Timeseries parameter test helpers ---- ##
+
+
+def sts_test_procedure_timeseries_param(
+    sts_properties: STStorageProperties,
+    tested_param_key: str,
+    base_timeseries: pd.DataFrame,
+    load_time_serie_file: str,
+    auto_generated_studies_path: Path,
+    antares_exec_folder: Path,
+    sts_timeseries_extra: Optional[dict[str, pd.DataFrame]] = None,
+) -> None:
+    """Test that a timeseries parameter is correctly handled by the GEMS model.
+
+    Creates a base study with the given timeseries, converts it, verifies near-zero
+    relative gap, then creates a perturbed study with MODIFICATION_RATIO * base_timeseries
+    and verifies the gap with the original converted study is significantly larger.
+    """
+    base_sts_timeseries = {tested_param_key: base_timeseries}
+    if sts_timeseries_extra:
+        base_sts_timeseries.update(sts_timeseries_extra)
+
+    study_name_base = f"e2e_{str(int(100*time()))}"
+    createSTSTestAntaresStudy(
+        study_name_base,
+        auto_generated_studies_path,
+        LOAD_FILES_DIR / load_time_serie_file,
+        sts_properties,
+        sts_timeseries=base_sts_timeseries,
+    )
+    original_study_path, converted_study_path = convert_study(
+        auto_generated_studies_path, study_name_base, ["short-term-storage"]
+    )
+    rel_gap = first_optim_relgap(
+        antares_exec_folder, original_study_path, converted_study_path, STS_TEST_SOLVER
+    )
+    assert rel_gap < STS_TEST_REL_ACCURACY
+
+    perturbed_timeseries = base_timeseries * MODIFICATION_RATIO
+    perturbed_sts_timeseries = {tested_param_key: perturbed_timeseries}
+    if sts_timeseries_extra:
+        perturbed_sts_timeseries.update(sts_timeseries_extra)
+
+    study_name_perturbed = f"e2e_{str(int(100*time()))}"
+    createSTSTestAntaresStudy(
+        study_name_perturbed,
+        auto_generated_studies_path,
+        LOAD_FILES_DIR / load_time_serie_file,
+        sts_properties,
+        sts_timeseries=perturbed_sts_timeseries,
+    )
+    rel_gap_perturbed = first_optim_relgap(
+        antares_exec_folder,
+        auto_generated_studies_path / study_name_perturbed,
+        converted_study_path,
+        STS_TEST_SOLVER,
+    )
+    assert rel_gap_perturbed > 100 * STS_TEST_REL_ACCURACY
+
+
+## ---- Tests for timeseries parameters ---- ##
+
+
+@pytest.mark.parametrize("load_time_serie_file", LOAD_TIME_SERIE_FILES_STS)
+def test_p_max_injection(
+    load_time_serie_file: str,
+    auto_generated_studies_path: Path,
+    antares_exec_folder: Path,
+) -> None:
+    sts_properties = STStorageProperties(
+        group="battery",
+        injection_nominal_capacity=100,
+        withdrawal_nominal_capacity=100,
+        reservoir_capacity=300,
+        efficiency=1,
+        initial_level=0.5,
+    )
+    base_timeseries = pd.DataFrame(0.5 * np.ones((8760, 1)))
+    sts_test_procedure_timeseries_param(
+        sts_properties,
+        "pmax_injection",
+        base_timeseries,
+        load_time_serie_file,
+        auto_generated_studies_path,
+        antares_exec_folder,
+    )
+
+
+@pytest.mark.parametrize("load_time_serie_file", LOAD_TIME_SERIE_FILES_STS)
+def test_p_max_withdrawal(
+    load_time_serie_file: str,
+    auto_generated_studies_path: Path,
+    antares_exec_folder: Path,
+) -> None:
+    sts_properties = STStorageProperties(
+        group="battery",
+        injection_nominal_capacity=100,
+        withdrawal_nominal_capacity=100,
+        reservoir_capacity=300,
+        efficiency=1,
+        initial_level=0.5,
+    )
+    base_timeseries = pd.DataFrame(0.5 * np.ones((8760, 1)))
+    sts_test_procedure_timeseries_param(
+        sts_properties,
+        "pmax_withdrawal",
+        base_timeseries,
+        load_time_serie_file,
+        auto_generated_studies_path,
+        antares_exec_folder,
+    )
+
+
+@pytest.mark.parametrize("load_time_serie_file", LOAD_TIME_SERIE_FILES_STS)
+def test_lower_rule_curve(
+    load_time_serie_file: str,
+    auto_generated_studies_path: Path,
+    antares_exec_folder: Path,
+) -> None:
+    sts_properties = STStorageProperties(
+        group="battery",
+        injection_nominal_capacity=100,
+        withdrawal_nominal_capacity=100,
+        reservoir_capacity=300,
+        efficiency=1,
+        initial_level=0.5,
+    )
+    base_timeseries = pd.DataFrame(0.1 * np.ones((8760, 1)))
+    sts_test_procedure_timeseries_param(
+        sts_properties,
+        "lower_rule_curve",
+        base_timeseries,
+        load_time_serie_file,
+        auto_generated_studies_path,
+        antares_exec_folder,
+    )
+
+
+@pytest.mark.parametrize("load_time_serie_file", LOAD_TIME_SERIE_FILES_STS)
+def test_upper_rule_curve(
+    load_time_serie_file: str,
+    auto_generated_studies_path: Path,
+    antares_exec_folder: Path,
+) -> None:
+    sts_properties = STStorageProperties(
+        group="battery",
+        injection_nominal_capacity=100,
+        withdrawal_nominal_capacity=100,
+        reservoir_capacity=300,
+        efficiency=1,
+        initial_level=0.5,
+    )
+    base_timeseries = pd.DataFrame(0.8 * np.ones((8760, 1)))
+    sts_test_procedure_timeseries_param(
+        sts_properties,
+        "upper_rule_curve",
+        base_timeseries,
+        load_time_serie_file,
+        auto_generated_studies_path,
+        antares_exec_folder,
+    )
+
+
+@pytest.mark.parametrize("load_time_serie_file", LOAD_TIME_SERIE_FILES_STS)
+def test_storage_inflows(
+    load_time_serie_file: str,
+    auto_generated_studies_path: Path,
+    antares_exec_folder: Path,
+) -> None:
+    sts_properties = STStorageProperties(
+        group="battery",
+        injection_nominal_capacity=100,
+        withdrawal_nominal_capacity=100,
+        reservoir_capacity=300,
+        efficiency=1,
+        initial_level=0.5,
+    )
+    base_timeseries = pd.DataFrame(5.0 * np.ones((8760, 1)))
+    sts_test_procedure_timeseries_param(
+        sts_properties,
+        "storage_inflows",
+        base_timeseries,
+        load_time_serie_file,
+        auto_generated_studies_path,
+        antares_exec_folder,
+    )
+
+
+## ---- Tests for cost timeseries parameters ---- ##
+
+
+@pytest.mark.parametrize("load_time_serie_file", LOAD_TIME_SERIE_FILES_STS)
+def test_cost_injection(
+    load_time_serie_file: str,
+    auto_generated_studies_path: Path,
+    antares_exec_folder: Path,
+) -> None:
+    sts_properties = STStorageProperties(
+        group="battery",
+        injection_nominal_capacity=100,
+        withdrawal_nominal_capacity=100,
+        reservoir_capacity=300,
+        efficiency=1,
+        initial_level=0.5,
+    )
+    base_timeseries = pd.DataFrame(5.0 * np.ones((8760, 1)))
+    sts_test_procedure_timeseries_param(
+        sts_properties,
+        "cost_injection",
+        base_timeseries,
+        load_time_serie_file,
+        auto_generated_studies_path,
+        antares_exec_folder,
+    )
+
+
+@pytest.mark.parametrize("load_time_serie_file", LOAD_TIME_SERIE_FILES_STS)
+def test_cost_withdrawal(
+    load_time_serie_file: str,
+    auto_generated_studies_path: Path,
+    antares_exec_folder: Path,
+) -> None:
+    sts_properties = STStorageProperties(
+        group="battery",
+        injection_nominal_capacity=100,
+        withdrawal_nominal_capacity=100,
+        reservoir_capacity=300,
+        efficiency=1,
+        initial_level=0.5,
+    )
+    base_timeseries = pd.DataFrame(5.0 * np.ones((8760, 1)))
+    sts_test_procedure_timeseries_param(
+        sts_properties,
+        "cost_withdrawal",
+        base_timeseries,
+        load_time_serie_file,
+        auto_generated_studies_path,
+        antares_exec_folder,
+    )
+
+
+@pytest.mark.parametrize("load_time_serie_file", LOAD_TIME_SERIE_FILES_STS)
+def test_cost_level(
+    load_time_serie_file: str,
+    auto_generated_studies_path: Path,
+    antares_exec_folder: Path,
+) -> None:
+    sts_properties = STStorageProperties(
+        group="battery",
+        injection_nominal_capacity=100,
+        withdrawal_nominal_capacity=100,
+        reservoir_capacity=300,
+        efficiency=1,
+        initial_level=0.5,
+    )
+    base_timeseries = pd.DataFrame(1.0 * np.ones((8760, 1)))
+    sts_test_procedure_timeseries_param(
+        sts_properties,
+        "cost_level",
+        base_timeseries,
         load_time_serie_file,
         auto_generated_studies_path,
         antares_exec_folder,

--- a/tests/antares_historic/test_sts_model.py
+++ b/tests/antares_historic/test_sts_model.py
@@ -361,7 +361,6 @@ def sts_test_procedure_timeseries_param(
     load_time_serie_file: str,
     auto_generated_studies_path: Path,
     antares_exec_folder: Path,
-    sts_timeseries_extra: Optional[dict[str, pd.DataFrame]] = None,
 ) -> None:
     """Test that a timeseries parameter is correctly handled by the GEMS model.
 
@@ -370,8 +369,6 @@ def sts_test_procedure_timeseries_param(
     and verifies the gap with the original converted study is significantly larger.
     """
     base_sts_timeseries = {tested_param_key: base_timeseries}
-    if sts_timeseries_extra:
-        base_sts_timeseries.update(sts_timeseries_extra)
 
     study_name_base = f"e2e_{str(int(100*time()))}"
     createSTSTestAntaresStudy(
@@ -391,8 +388,6 @@ def sts_test_procedure_timeseries_param(
 
     perturbed_timeseries = base_timeseries * MODIFICATION_RATIO
     perturbed_sts_timeseries = {tested_param_key: perturbed_timeseries}
-    if sts_timeseries_extra:
-        perturbed_sts_timeseries.update(sts_timeseries_extra)
 
     study_name_perturbed = f"e2e_{str(int(100*time()))}"
     createSTSTestAntaresStudy(

--- a/tests/antares_historic/utils.py
+++ b/tests/antares_historic/utils.py
@@ -195,12 +195,24 @@ def createLinkTestAntaresStudy(
     addHybridBehavior(parent_dir_path / study_name)
 
 
+STS_TIMESERIES_SETTER_MAP = {
+    "cost_injection": "set_cost_injection",
+    "cost_withdrawal": "set_cost_withdrawal",
+    "cost_level": "set_cost_level",
+    "pmax_injection": "update_pmax_injection",
+    "pmax_withdrawal": "set_pmax_withdrawal",
+    "lower_rule_curve": "set_lower_rule_curve",
+    "upper_rule_curve": "set_upper_rule_curve",
+    "storage_inflows": "set_storage_inflows",
+}
+
+
 def createSTSTestAntaresStudy(
     study_name: str,
     parent_dir_path: Path,
     load_time_serie_file: Path,
     sts_properties: STStorageProperties,
-    # sts_data_frame: pd.DataFrame,
+    sts_timeseries: Optional[dict[str, pd.DataFrame]] = None,
 ) -> None:
     study = create_study_local(
         study_name=study_name,
@@ -237,6 +249,9 @@ def createSTSTestAntaresStudy(
     cluster2.set_series(pd.DataFrame(data=400 * np.ones((8760, 1))))
 
     cluster3 = area.create_st_storage("sts", sts_properties)
+    if sts_timeseries:
+        for key, df in sts_timeseries.items():
+            getattr(cluster3, STS_TIMESERIES_SETTER_MAP[key])(df)
     addHybridBehavior(parent_dir_path / study_name)
 
 

--- a/tests/input_converter/test_converter.py
+++ b/tests/input_converter/test_converter.py
@@ -294,6 +294,9 @@ class TestConverter:
         pmax_injection_path = "p_max_injection_modulation_fr_storage_1"
         pmax_withdrawal_path = "p_max_withdrawal_modulation_fr_storage_1"
         upper_rule_curve_path = "upper_rule_curve_fr_storage_1"
+        cost_injection_path = "cost_injection_fr_storage_1"
+        cost_withdrawal_path = "cost_withdrawal_fr_storage_1"
+        cost_level_path = "cost_level_fr_storage_1"
         expected_storage_connections = [
             InputPortConnections(
                 component1="fr_storage_1",
@@ -384,6 +387,27 @@ class TestConverter:
                         scenario_dependent=False,
                         scenario_group=None,
                         value=0.5,
+                    ),
+                    InputComponentParameter(
+                        id="cost_injection",
+                        time_dependent=True,
+                        scenario_dependent=True,
+                        scenario_group=None,
+                        value=f"{cost_injection_path}",
+                    ),
+                    InputComponentParameter(
+                        id="cost_withdrawal",
+                        time_dependent=True,
+                        scenario_dependent=True,
+                        scenario_group=None,
+                        value=f"{cost_withdrawal_path}",
+                    ),
+                    InputComponentParameter(
+                        id="cost_level",
+                        time_dependent=True,
+                        scenario_dependent=True,
+                        scenario_group=None,
+                        value=f"{cost_level_path}",
                     ),
                 ],
             )


### PR DESCRIPTION
## Add `cost_injection`, `cost_withdrawal`, and `cost_level` to the ST-Storage GEMS Model + tests for 8 timeseries parameters

### Summary

This PR introduces support for three cost parameters of short-term storage (ST-Storage) units: `cost_injection`, `cost_withdrawal`, and `cost_level`. These parameters were previously missing from both the legacy model definition and the GEMS model configuration, meaning storage operational costs were not captured during conversion and optimization.

This PR also introduce tests for 8 timeseries parameters (see Section 5 below)

---

### Changes

#### 1. `antares_legacy_models.yml` — ST-Storage legacy model definition

- Added three new parameters to the `st_storage` model:
  - `cost_injection` (time-dependent, scenario-dependent)
  - `cost_withdrawal` (time-dependent, scenario-dependent)
  - `cost_level` (time-dependent, scenario-dependent)
- Added an **objective contribution** to the model: `sum(cost_injection * p_injection + cost_withdrawal * p_withdrawal + cost_level * level) `

This makes the storage operational costs part of the optimization objective.

#### 2. `st-storage.yaml` — GEMS model configuration template

- Added the three new cost parameters (`cost_injection`, `cost_withdrawal`, `cost_level`) as time- and scenario-dependent parameters bound to the corresponding `st_storage` fields via `object-properties`.

#### 3. `tests/input_converter/test_converter.py` — Converter unit test

- Extended the expected output of the converter test to include the three new cost parameters (`cost_injection`, `cost_withdrawal`, `cost_level`) as `InputComponentParameter` entries, each with `time_dependent=True` and `scenario_dependent=True`.

#### 4. `tests/antares_historic/utils.py` — Test utilities

- Added a `STS_TIMESERIES_SETTER_MAP` dictionary mapping parameter keys (e.g. `"cost_injection"`) to their corresponding `antares.craft` API setter method names (e.g. `"set_cost_injection"`). This map now covers all 8 timeseries parameters: `cost_injection`, `cost_withdrawal`, `cost_level`, `pmax_injection`, `pmax_withdrawal`, `lower_rule_curve`, `upper_rule_curve`, `storage_inflows`.
- Refactored `createSTSTestAntaresStudy` to accept an optional `sts_timeseries: dict[str, pd.DataFrame]` argument, applying each timeseries to the storage cluster via the setter map.

#### 5. `tests/antares_historic/test_sts_model.py` — End-to-end ST-Storage tests

- Added a reusable `sts_test_procedure_timeseries_param` helper that:
1. Creates an Antares study with a base timeseries for the parameter under test.
2. Converts the study and verifies the optimization relative gap is below the accuracy threshold.
3. Creates a perturbed study (timeseries scaled by `MODIFICATION_RATIO`) and verifies the gap against the original converted study is significantly larger — confirming the parameter has a measurable effect.
- Added 8 new end-to-end parametric tests, covering all previously `TODO` timeseries parameters:
- `test_p_max_injection`
- `test_p_max_withdrawal`
- `test_lower_rule_curve`
- `test_upper_rule_curve`
- `test_storage_inflows`
- `test_cost_injection`
- `test_cost_withdrawal`
- `test_cost_level` 
- Updated the TODO tracking comment block to mark all 8 as `[OK]`.
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 