### PR TITLE
Notify GEMS repo about Antares Legacy models library update

### DIFF
--- a/.github/ISSUE_TEMPLATE/a2g-01.yml
+++ b/.github/ISSUE_TEMPLATE/a2g-01.yml
@@ -98,6 +98,7 @@ body:
 
         ### Step 8 — Versioning
         - [ ] `dependencies.json` updated (`antares_simulator_version`)
+        - [ ] `dependencies.json` updated (`antares_legacy_models_library_version`) if library changed
         - [ ] `pyproject.toml` version bumped (Major if Antares major bump, Minor otherwise)
 
         ### Step 9 — Release

--- a/.github/ISSUE_TEMPLATE/a2g-02.yml
+++ b/.github/ISSUE_TEMPLATE/a2g-02.yml
@@ -108,6 +108,7 @@ body:
 
         ### Step 8 — Versioning
         - [ ] `pyproject.toml` version bumped if converter logic changed
+        - [ ] `dependencies.json` updated (`antares_legacy_models_library_version`) if library changed
 
         ### Step 9 — Release
         - [ ] Release documents changes, compatibility, and behaviour changes

--- a/.github/workflows/notify-gems-antares-legacy-models-update.yml
+++ b/.github/workflows/notify-gems-antares-legacy-models-update.yml
@@ -8,32 +8,51 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write  # required to push the library version tag
 
 jobs:
   notify:
+    name: Check Antares Legacy models library version and notify GEMS
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repository
+      - name: Checkout repository with full history
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      - name: Read library version
+      - name: Read current and previous library version
         id: version
         run: |
-          LAST_TAG=$(git describe --tags --abbrev=0 HEAD^1 2>/dev/null || echo "")
-          if [ -z "$LAST_TAG" ]; then
-            PREV=""
-          else
-            PREV=$(git show ${LAST_TAG}:dependencies.json | python3 -c "import json,sys; print(json.load(sys.stdin).get('antares_legacy_models_library_version',''))")
-          fi
           CURR=$(python3 -c "import json; print(json.load(open('dependencies.json'))['antares_legacy_models_library_version'])")
           echo "version=$CURR" >> "$GITHUB_OUTPUT"
-          if [ "$PREV" = "$CURR" ]; then
+
+          LAST_TAG=$(git tag --list 'antares_legacy_models-v*' --sort=-creatordate | head -1)
+          if [ -z "$LAST_TAG" ]; then
+            echo "No previous library tag found."
+            PREV=""
+          else
+            echo "Last library tag: $LAST_TAG"
+            PREV=$(git show "${LAST_TAG}:dependencies.json" 2>/dev/null \
+              | python3 -c "import json,sys; print(json.load(sys.stdin).get('antares_legacy_models_library_version',''))")
+          fi
+
+          echo "Current: $CURR  |  Previous: $PREV"
+          if [ "$CURR" = "$PREV" ]; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Create library version tag
+        if: steps.version.outputs.changed == 'true'
+        run: |
+          TAG="antares_legacy_models-v${{ steps.version.outputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "$TAG"
+          git push origin "$TAG"
+          echo "Created and pushed tag: $TAG"
 
       - name: Create issue in GEMS repository
         if: steps.version.outputs.changed == 'true'
@@ -41,9 +60,9 @@ jobs:
         with:
           github-token: ${{ secrets.GEMS_REPO_PAT }}
           script: |
-            const version = '${{ steps.version.outputs.version }}';
-            const converterRepo = context.repo.repo;
+            const version       = '${{ steps.version.outputs.version }}';
             const converterOwner = context.repo.owner;
+            const converterRepo  = context.repo.repo;
             const title = `[ANTARES LEGACY MODELS] New library version: v${version}`;
 
             const existing = await github.rest.issues.listForRepo({

--- a/.github/workflows/notify-gems-antares-legacy-models-update.yml
+++ b/.github/workflows/notify-gems-antares-legacy-models-update.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Read library version
         id: version
         run: |
-          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          LAST_TAG=$(git describe --tags --abbrev=0 HEAD^1 2>/dev/null || echo "")
           if [ -z "$LAST_TAG" ]; then
             PREV=""
           else

--- a/.github/workflows/notify-gems-antares-legacy-models-update.yml
+++ b/.github/workflows/notify-gems-antares-legacy-models-update.yml
@@ -71,7 +71,6 @@ jobs:
               repo: 'GEMS',
               title: title,
               body: body,
-              labels: ['antares-legacy-models-update'],
             });
 
             console.log(`Issue created: #${result.data.number} — ${result.data.html_url}`);

--- a/.github/workflows/notify-gems-antares-legacy-models-update.yml
+++ b/.github/workflows/notify-gems-antares-legacy-models-update.yml
@@ -1,0 +1,77 @@
+name: Notify GEMS — Antares Legacy Models Library Update
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'dependencies.json'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Read library version
+        id: version
+        run: |
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [ -z "$LAST_TAG" ]; then
+            PREV=""
+          else
+            PREV=$(git show ${LAST_TAG}:dependencies.json | python3 -c "import json,sys; print(json.load(sys.stdin).get('antares_legacy_models_library_version',''))")
+          fi
+          CURR=$(python3 -c "import json; print(json.load(open('dependencies.json'))['antares_legacy_models_library_version'])")
+          echo "version=$CURR" >> "$GITHUB_OUTPUT"
+          if [ "$PREV" = "$CURR" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create issue in GEMS repository
+        if: steps.version.outputs.changed == 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GEMS_REPO_PAT }}
+          script: |
+            const version = '${{ steps.version.outputs.version }}';
+            const converterRepo = context.repo.repo;
+            const converterOwner = context.repo.owner;
+            const title = `[ANTARES LEGACY MODELS] New library version: v${version}`;
+
+            const existing = await github.rest.issues.listForRepo({
+              owner: converterOwner,
+              repo: 'GEMS',
+              state: 'open',
+            });
+
+            const duplicate = existing.data.find(i => i.title.includes(`v${version}`));
+            if (duplicate) {
+              console.log(`Issue already exists: #${duplicate.number} — skipping.`);
+              return;
+            }
+
+            const body = [
+              `Antares Legacy models library updated to \`v${version}\` in [${converterRepo}](https://github.com/${converterOwner}/${converterRepo}).`,
+              '',
+              `Changelog: https://github.com/${converterOwner}/${converterRepo}/blob/main/src/antares_gems_converter/libs/antares_historic/CHANGELOG-antares_legacy_models_library.md`,
+              '',
+              'Update `libraries/antares_legacy_models.yml` in GEMS accordingly.',
+            ].join('\n');
+
+            const result = await github.rest.issues.create({
+              owner: converterOwner,
+              repo: 'GEMS',
+              title: title,
+              body: body,
+              labels: ['antares-legacy-models-update'],
+            });
+
+            console.log(`Issue created: #${result.data.number} — ${result.data.html_url}`);

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -13,7 +13,7 @@ This table maps converter versions to the tool versions they are compatible with
   - **Minor** — Bug fix, new feature, or antares-craft/GemsPy version update
   - **Patch** — Dependency updates, code optimisation, or library-only change
 
-- **Antares Legacy Models Library** — version tracked in `src/antares_gems_converter/libs/antares_historic/CHANGELOG-antares_legacy_models_library.md` (latest entry header). Independent versioning:
+- **Antares Legacy Models Library** — version tracked in `dependencies.json` (`antares_legacy_models_library_version`). Independent versioning:
   - **Major** — New legacy model added to `antares_legacy_models.yml`
   - **Minor** — Bug fix or improvement to an existing model
   - **Patch** — Non-functional change (rename variable/parameter, internal refactor)
@@ -34,7 +34,7 @@ This table maps converter versions to the tool versions they are compatible with
 | Component | Current Version | Version File |
 |-----------|----------------|--------------|
 | Converter | 0.0.1 | `pyproject.toml` |
-| Antares Legacy Models Library | 1.0.0 | `src/antares_gems_converter/libs/antares_historic/CHANGELOG-antares_legacy_models_library.md` |
+| Antares Legacy Models Library | 1.0.0 | `dependencies.json` |
 | Antares-Simulator | 10.0.0 | `dependencies.json` |
 | antares-craft | 0.3.0 | `requirements.txt` |
 | GemsPy | 0.0.2 | `requirements.txt` |

--- a/dependencies.json
+++ b/dependencies.json
@@ -1,3 +1,4 @@
 {
-  "antares_simulator_version": "10.0.0"
+  "antares_simulator_version": "10.0.0",
+  "antares_legacy_models_library_version": "1.0.0"
 }


### PR DESCRIPTION
- [x] Track Antares Legacy models library version in dependencies.json (antares_legacy_models_library_version).
- [x] Update COMPATIBILITY.md accordingly.
- [x] Add `notify-gems-antares-legacy-models-update` workflow: triggers on dependencies.json changes, compares against the last git tag, and creates an issue in GEMS only when the library version changed. 
- [x] Issue templates updated with the dependencies.json versioning step.
- [x] Create GEMS_REPO_PAT (token) and add it in Antares Legacy  Converter repository as a secret