### PR TITLE
[A2G-04] Adapt the Converter to GemsPy 0.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,7 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Antares Simulator binary downloaded for tests/antares_historic/
+antares-*-Ubuntu-*/
+antares-*-Ubuntu-*.tar.gz

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -4,6 +4,7 @@ This table maps converter versions to the tool versions they are compatible with
 
 | Converter | Antares-Simulator | antares-craft | GemsPy | Notes |
 |-----------|-------------------|---------------|--------|-------|
+| 0.1.0     | 10.0.0            | 0.3.0         | 0.1.0  | Adapt to GemsPy 0.1.0 (massive refactoring: rename Input* classes to *Schema) |
 | 0.0.1     | 10.0.0            | 0.3.0         | 0.0.2  | Initial release |
 
 ## Versioning Policy
@@ -33,8 +34,8 @@ This table maps converter versions to the tool versions they are compatible with
 
 | Component | Current Version | Version File |
 |-----------|----------------|--------------|
-| Converter | 0.0.1 | `pyproject.toml` |
+| Converter | 0.1.0 | `pyproject.toml` |
 | Antares Legacy Models Library | 1.0.0 | `src/antares_gems_converter/libs/antares_historic/antares_legacy_models.yml` |
 | Antares-Simulator | 10.0.0 | `dependencies.json` |
 | antares-craft | 0.3.0 | `requirements.txt` |
-| GemsPy | 0.0.2 | `requirements.txt` |
+| GemsPy | 0.1.0 | `requirements.txt` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antares-legacy-gems-converter"
-version = "0.0.1"
+version = "0.1.0"
 description = "Convert Antares Legacy studies to GEMS format"
 license = {text = "MPL-2.0"}
 requires-python = ">=3.10"
 dependencies = [
-    "gemspy",
+    "gemspy==0.1.0",
     "numpy",
     "PyYAML>=6.0",
     "pydantic",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,18 +4,12 @@
 #
 #    pip-compile --output-file=requirements-dev.txt requirements-dev.in
 #
-absl-py==2.3.1
-    # via
-    #   -r requirements.txt
-    #   ortools
 annotated-types==0.7.0
     # via
     #   -r requirements.txt
     #   pydantic
 antares-craft==0.3.0
-    # via
-    #   -r requirements.txt
-    #   gemspy
+    # via -r requirements.txt
 antares-study-version==1.0.15
     # via
     #   -r requirements.txt
@@ -24,16 +18,21 @@ antares-timeseries-generation==0.1.7
     # via
     #   -r requirements.txt
     #   antares-craft
-antlr4-python3-runtime==4.13.1
+antlr4-python3-runtime==4.13.2
     # via
     #   -r requirements.txt
     #   gemspy
-anytree==2.12.1
+anytree==2.13.0
     # via
     #   -r requirements.txt
     #   gemspy
-attrs==25.3.0
-    # via pytest
+attrs==26.1.0
+    # via
+    #   -r requirements.txt
+    #   gemspy
+    #   pytest
+black==23.7.0
+    # via -r requirements-dev.in
 bottleneck==1.6.0
     # via
     #   -r requirements.txt
@@ -41,18 +40,11 @@ bottleneck==1.6.0
 certifi==2025.1.31
     # via
     #   -r requirements.txt
-    #   netcdf4
-    #   pyogrio
-    #   pyproj
     #   requests
 cffi==2.0.0
     # via
     #   -r requirements.txt
     #   cryptography
-cftime==1.6.5
-    # via
-    #   -r requirements.txt
-    #   netcdf4
 charset-normalizer==3.4.1
     # via
     #   -r requirements.txt
@@ -61,25 +53,18 @@ click==8.1.8
     # via
     #   -r requirements.txt
     #   antares-study-version
+    #   black
     #   dask
 cloudpickle==3.1.2
     # via
     #   -r requirements.txt
     #   dask
-contourpy==1.3.3
-    # via
-    #   -r requirements.txt
-    #   matplotlib
 coverage[toml]==7.8.0
     # via pytest-cov
 cryptography==46.0.4
     # via
     #   -r requirements.txt
     #   google-auth
-cycler==0.12.1
-    # via
-    #   -r requirements.txt
-    #   matplotlib
 dask==2026.1.2
     # via
     #   -r requirements.txt
@@ -88,21 +73,12 @@ deprecation==2.1.0
     # via
     #   -r requirements.txt
     #   linopy
-    #   pypsa
-fonttools==4.61.1
-    # via
-    #   -r requirements.txt
-    #   matplotlib
 fsspec==2026.2.0
     # via
     #   -r requirements.txt
     #   dask
-gemspy==0.0.2
+gemspy==0.1.0
     # via -r requirements.txt
-geopandas==1.1.2
-    # via
-    #   -r requirements.txt
-    #   pypsa
 google-api-core==2.29.0
     # via
     #   -r requirements.txt
@@ -135,69 +111,36 @@ googleapis-common-protos==1.72.0
     # via
     #   -r requirements.txt
     #   google-api-core
-highspy==1.13.0
+highspy==1.14.0
     # via
     #   -r requirements.txt
-    #   pypsa
+    #   gemspy
 idna==3.11
     # via
     #   -r requirements.txt
     #   requests
-immutabledict==4.2.1
-    # via
-    #   -r requirements.txt
-    #   ortools
 importlib-metadata==8.7.1
     # via
     #   -r requirements.txt
     #   dask
 iniconfig==2.1.0
     # via pytest
-jinja2==3.1.6
-    # via
-    #   -r requirements.txt
-    #   pydeck
-kiwisolver==1.4.9
-    # via
-    #   -r requirements.txt
-    #   matplotlib
-levenshtein==0.27.3
-    # via
-    #   -r requirements.txt
-    #   pypsa
+librt==0.11.0
+    # via mypy
 linopy==0.6.1
     # via
     #   -r requirements.txt
-    #   pypsa
+    #   gemspy
 locket==1.0.0
     # via
     #   -r requirements.txt
     #   partd
-markupsafe==3.0.3
-    # via
-    #   -r requirements.txt
-    #   jinja2
-matplotlib==3.10.8
-    # via
-    #   -r requirements.txt
-    #   pypsa
-    #   seaborn
 mypy==1.19.1
     # via -r requirements-dev.in
 mypy-extensions==1.1.0
-    # via mypy
-narwhals==2.16.0
     # via
-    #   -r requirements.txt
-    #   plotly
-netcdf4==1.7.3
-    # via
-    #   -r requirements.txt
-    #   pypsa
-networkx==3.6.1
-    # via
-    #   -r requirements.txt
-    #   pypsa
+    #   black
+    #   mypy
 numexpr==2.14.1
     # via
     #   -r requirements.txt
@@ -208,38 +151,20 @@ numpy==1.26.4
     #   antares-craft
     #   antares-timeseries-generation
     #   bottleneck
-    #   cftime
-    #   contourpy
     #   gemspy
-    #   geopandas
     #   highspy
     #   linopy
-    #   matplotlib
-    #   netcdf4
     #   numexpr
-    #   ortools
     #   pandas
-    #   pydeck
-    #   pyogrio
-    #   pypsa
     #   scipy
-    #   seaborn
-    #   shapely
     #   xarray
-ortools==9.9.3963
-    # via
-    #   -r requirements.txt
-    #   gemspy
 packaging==25.0
     # via
     #   -r requirements.txt
+    #   black
     #   dask
     #   deprecation
-    #   geopandas
     #   linopy
-    #   matplotlib
-    #   plotly
-    #   pyogrio
     #   pytest
     #   xarray
 pandas==2.2.3
@@ -248,23 +173,18 @@ pandas==2.2.3
     #   antares-craft
     #   antares-study-version
     #   antares-timeseries-generation
-    #   geopandas
-    #   ortools
-    #   pypsa
-    #   seaborn
+    #   gemspy
     #   xarray
 partd==1.4.2
     # via
     #   -r requirements.txt
     #   dask
-pillow==12.1.0
+pathspec==1.1.1
     # via
-    #   -r requirements.txt
-    #   matplotlib
-plotly==6.5.2
-    # via
-    #   -r requirements.txt
-    #   pypsa
+    #   black
+    #   mypy
+platformdirs==4.9.6
+    # via black
 pluggy==1.5.0
     # via
     #   pytest
@@ -286,7 +206,6 @@ protobuf==6.32.0
     #   -r requirements.txt
     #   google-api-core
     #   googleapis-common-protos
-    #   ortools
     #   proto-plus
 psutil==7.0.0
     # via
@@ -316,26 +235,6 @@ pydantic-core==2.33.2
     # via
     #   -r requirements.txt
     #   pydantic
-pydeck==0.9.1
-    # via
-    #   -r requirements.txt
-    #   pypsa
-pyogrio==0.12.1
-    # via
-    #   -r requirements.txt
-    #   geopandas
-pyparsing==3.3.2
-    # via
-    #   -r requirements.txt
-    #   matplotlib
-pyproj==3.7.2
-    # via
-    #   -r requirements.txt
-    #   geopandas
-pypsa==1.0.7
-    # via
-    #   -r requirements.txt
-    #   gemspy
 pytest==7.0.1
     # via
     #   -r requirements-dev.in
@@ -345,7 +244,6 @@ pytest-cov==6.3.0
 python-dateutil==2.9.0.post0
     # via
     #   -r requirements.txt
-    #   matplotlib
     #   pandas
 pytz==2025.2
     # via
@@ -357,10 +255,6 @@ pyyaml==6.0.2
     #   antares-timeseries-generation
     #   dask
     #   gemspy
-rapidfuzz==3.14.3
-    # via
-    #   -r requirements.txt
-    #   levenshtein
 requests==2.32.3
     # via
     #   -r requirements.txt
@@ -375,22 +269,10 @@ rsa==4.9.1
 scipy==1.17.0
     # via
     #   -r requirements.txt
-    #   gemspy
     #   linopy
-    #   pypsa
-seaborn==0.13.2
-    # via
-    #   -r requirements.txt
-    #   pypsa
-shapely==2.1.2
-    # via
-    #   -r requirements.txt
-    #   geopandas
-    #   pypsa
 six==1.17.0
     # via
     #   -r requirements.txt
-    #   anytree
     #   python-dateutil
 tomli==2.2.1
     # via pytest
@@ -409,6 +291,7 @@ types-pyyaml==6.0.12.20250915
 typing-extensions==4.13.2
     # via
     #   -r requirements.txt
+    #   mypy
     #   pydantic
     #   pydantic-core
     #   typing-inspection
@@ -424,15 +307,11 @@ urllib3==2.4.0
     # via
     #   -r requirements.txt
     #   requests
-validators==0.35.0
-    # via
-    #   -r requirements.txt
-    #   pypsa
 xarray==2026.1.0
     # via
     #   -r requirements.txt
+    #   gemspy
     #   linopy
-    #   pypsa
 zipp==3.23.0
     # via
     #   -r requirements.txt

--- a/requirements.in
+++ b/requirements.in
@@ -3,4 +3,4 @@ PyYAML~=6.0.1
 pydantic
 antares_craft>=0.3
 pandas
-gemspy
+gemspy==0.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,34 +4,26 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
-absl-py==2.3.1
-    # via ortools
 annotated-types==0.7.0
     # via pydantic
 antares-craft==0.3.0
-    # via
-    #   -r requirements.in
-    #   gemspy
+    # via -r requirements.in
 antares-study-version==1.0.15
     # via antares-craft
 antares-timeseries-generation==0.1.7
     # via antares-craft
-antlr4-python3-runtime==4.13.1
+antlr4-python3-runtime==4.13.2
     # via gemspy
-anytree==2.12.1
+anytree==2.13.0
+    # via gemspy
+attrs==26.1.0
     # via gemspy
 bottleneck==1.6.0
     # via linopy
 certifi==2025.1.31
-    # via
-    #   netcdf4
-    #   pyogrio
-    #   pyproj
-    #   requests
+    # via requests
 cffi==2.0.0
     # via cryptography
-cftime==1.6.5
-    # via netcdf4
 charset-normalizer==3.4.1
     # via requests
 click==8.1.8
@@ -40,26 +32,16 @@ click==8.1.8
     #   dask
 cloudpickle==3.1.2
     # via dask
-contourpy==1.3.3
-    # via matplotlib
 cryptography==46.0.4
     # via google-auth
-cycler==0.12.1
-    # via matplotlib
 dask==2026.1.2
     # via linopy
 deprecation==2.1.0
-    # via
-    #   linopy
-    #   pypsa
-fonttools==4.61.1
-    # via matplotlib
+    # via linopy
 fsspec==2026.2.0
     # via dask
-gemspy==0.0.2
+gemspy==0.1.0
     # via -r requirements.in
-geopandas==1.1.2
-    # via pypsa
 google-api-core==2.29.0
     # via
     #   google-cloud-core
@@ -81,36 +63,16 @@ google-resumable-media==2.8.0
     # via google-cloud-storage
 googleapis-common-protos==1.72.0
     # via google-api-core
-highspy==1.13.0
-    # via pypsa
+highspy==1.14.0
+    # via gemspy
 idna==3.11
     # via requests
-immutabledict==4.2.1
-    # via ortools
 importlib-metadata==8.7.1
     # via dask
-jinja2==3.1.6
-    # via pydeck
-kiwisolver==1.4.9
-    # via matplotlib
-levenshtein==0.27.3
-    # via pypsa
 linopy==0.6.1
-    # via pypsa
+    # via gemspy
 locket==1.0.0
     # via partd
-markupsafe==3.0.3
-    # via jinja2
-matplotlib==3.10.8
-    # via
-    #   pypsa
-    #   seaborn
-narwhals==2.16.0
-    # via plotly
-netcdf4==1.7.3
-    # via pypsa
-networkx==3.6.1
-    # via pypsa
 numexpr==2.14.1
     # via linopy
 numpy==1.26.4
@@ -119,35 +81,18 @@ numpy==1.26.4
     #   antares-craft
     #   antares-timeseries-generation
     #   bottleneck
-    #   cftime
-    #   contourpy
     #   gemspy
-    #   geopandas
     #   highspy
     #   linopy
-    #   matplotlib
-    #   netcdf4
     #   numexpr
-    #   ortools
     #   pandas
-    #   pydeck
-    #   pyogrio
-    #   pypsa
     #   scipy
-    #   seaborn
-    #   shapely
     #   xarray
-ortools==9.9.3963
-    # via gemspy
 packaging==25.0
     # via
     #   dask
     #   deprecation
-    #   geopandas
     #   linopy
-    #   matplotlib
-    #   plotly
-    #   pyogrio
     #   xarray
 pandas==2.2.3
     # via
@@ -155,17 +100,10 @@ pandas==2.2.3
     #   antares-craft
     #   antares-study-version
     #   antares-timeseries-generation
-    #   geopandas
-    #   ortools
-    #   pypsa
-    #   seaborn
+    #   gemspy
     #   xarray
 partd==1.4.2
     # via dask
-pillow==12.1.0
-    # via matplotlib
-plotly==6.5.2
-    # via pypsa
 polars==1.38.1
     # via linopy
 polars-runtime-32==1.38.1
@@ -176,7 +114,6 @@ protobuf==6.32.0
     # via
     #   google-api-core
     #   googleapis-common-protos
-    #   ortools
     #   proto-plus
 psutil==7.0.0
     # via antares-craft
@@ -195,20 +132,8 @@ pydantic==2.11.7
     #   gemspy
 pydantic-core==2.33.2
     # via pydantic
-pydeck==0.9.1
-    # via pypsa
-pyogrio==0.12.1
-    # via geopandas
-pyparsing==3.3.2
-    # via matplotlib
-pyproj==3.7.2
-    # via geopandas
-pypsa==1.0.7
-    # via gemspy
 python-dateutil==2.9.0.post0
-    # via
-    #   matplotlib
-    #   pandas
+    # via pandas
 pytz==2025.2
     # via pandas
 pyyaml==6.0.2
@@ -217,8 +142,6 @@ pyyaml==6.0.2
     #   antares-timeseries-generation
     #   dask
     #   gemspy
-rapidfuzz==3.14.3
-    # via levenshtein
 requests==2.32.3
     # via
     #   antares-craft
@@ -228,20 +151,9 @@ requests==2.32.3
 rsa==4.9.1
     # via google-auth
 scipy==1.17.0
-    # via
-    #   gemspy
-    #   linopy
-    #   pypsa
-seaborn==0.13.2
-    # via pypsa
-shapely==2.1.2
-    # via
-    #   geopandas
-    #   pypsa
+    # via linopy
 six==1.17.0
-    # via
-    #   anytree
-    #   python-dateutil
+    # via python-dateutil
 toolz==1.1.0
     # via
     #   dask
@@ -260,11 +172,9 @@ tzdata==2025.2
     # via pandas
 urllib3==2.4.0
     # via requests
-validators==0.35.0
-    # via pypsa
 xarray==2026.1.0
     # via
+    #   gemspy
     #   linopy
-    #   pypsa
 zipp==3.23.0
     # via importlib-metadata

--- a/src/antares_gems_converter/input_converter/src/config.py
+++ b/src/antares_gems_converter/input_converter/src/config.py
@@ -23,7 +23,7 @@ TEMPLATE_CLUSTER_TYPE_TO_DELETE_METHOD = {
 STUDY_LEVEL_DELETION = {
     "area": "delete_area",
     "link": "delete_link",
-    "binding_constraint": "delete_binding_constraint",
+    "binding_constraint": "delete_binding_constraints",
 }
 STUDY_LEVEL_GET = {
     "area": "get_areas",

--- a/src/antares_gems_converter/input_converter/src/config.py
+++ b/src/antares_gems_converter/input_converter/src/config.py
@@ -23,7 +23,7 @@ TEMPLATE_CLUSTER_TYPE_TO_DELETE_METHOD = {
 STUDY_LEVEL_DELETION = {
     "area": "delete_area",
     "link": "delete_link",
-    "binding_constraint": "delete_binding_constraints",
+    "binding_constraint": "delete_binding_constraint",
 }
 STUDY_LEVEL_GET = {
     "area": "get_areas",

--- a/src/antares_gems_converter/input_converter/src/converter.py
+++ b/src/antares_gems_converter/input_converter/src/converter.py
@@ -47,11 +47,11 @@ from antares_gems_converter.input_converter.src.utils import (
     resolve_path,
 )
 from gems.study.parsing import (
-    InputAreaConnections,
-    InputComponent,
-    InputComponentParameter,
-    InputPortConnections,
-    InputSystem,
+    AreaConnectionsSchema,
+    ComponentParameterSchema,
+    ComponentSchema,
+    PortConnectionsSchema,
+    SystemSchema,
 )
 
 ANTARES_HISTORIC_LIB_ID = "antares_legacy_models"
@@ -127,23 +127,23 @@ class AntaresStudyConverter:
 
     def _convert_area_to_component_list(
         self, lib_id: str, excluded_areas: Optional[list[str]] = None
-    ) -> list[InputComponent]:
+    ) -> list[ComponentSchema]:
         components = []
         self.logger.info("Converting areas to component list...")
         for area in self.areas.values():
             if not excluded_areas or area.id not in excluded_areas:
                 components.append(
-                    InputComponent(
+                    ComponentSchema(
                         id=area.id,
                         model=f"{lib_id}.area",
                         parameters=[
-                            InputComponentParameter(
+                            ComponentParameterSchema(
                                 id="ens_cost",
                                 time_dependent=False,
                                 scenario_dependent=False,
                                 value=area.properties.energy_cost_unsupplied,
                             ),
-                            InputComponentParameter(
+                            ComponentParameterSchema(
                                 id="spillage_cost",
                                 time_dependent=False,
                                 scenario_dependent=False,
@@ -166,11 +166,9 @@ class AntaresStudyConverter:
                         id = legacy_component.binding_constraint_id
                     else:
                         continue
-                    getattr(self.study, STUDY_LEVEL_DELETION[legacy_component.type])(
-                        getattr(self.study, STUDY_LEVEL_GET[legacy_component.type])()[
-                            id
-                        ]
-                    )
+                    obj = getattr(self.study, STUDY_LEVEL_GET[legacy_component.type])()[id]
+                    arg = [obj] if legacy_component.type == "binding_constraint" else obj
+                    getattr(self.study, STUDY_LEVEL_DELETION[legacy_component.type])(arg)
                 elif (
                     legacy_component.type in TEMPLATE_CLUSTER_TYPE_TO_DELETE_METHOD
                     and legacy_component.area is not None
@@ -198,7 +196,7 @@ class AntaresStudyConverter:
                 self.logger.warning(
                     f"Item {legacy_component} will not be deleted because it is referenced in a binding constraint"
                 )
-            except KeyError:
+            except (KeyError, FileNotFoundError):
                 self.logger.warning(
                     f"Item {legacy_component} not found in study; skipping deletion"
                 )
@@ -218,7 +216,7 @@ class AntaresStudyConverter:
         mp: ModelConversionPreprocessor,
     ) -> None:
         parameters = [
-            InputComponentParameter(
+            ComponentParameterSchema(
                 id=param.id,
                 time_dependent=bool(param.time_dependent),
                 scenario_dependent=bool(param.scenario_dependent),
@@ -232,7 +230,7 @@ class AntaresStudyConverter:
             kwargs["scenario_group"] = scenario_group
 
         components.append(
-            InputComponent(
+            ComponentSchema(
                 id=(resolved_conversion_template.component.id).replace(" ", "_"),
                 model=resolved_conversion_template.model,
                 parameters=parameters,
@@ -260,7 +258,7 @@ class AntaresStudyConverter:
                     area_value = area_connection.area
                 area_value = area_value.replace(" ", "_")
                 area_connections.append(
-                    InputAreaConnections(
+                    AreaConnectionsSchema(
                         component=component_value,
                         port=area_connection.port,
                         area=area_value,
@@ -285,7 +283,7 @@ class AntaresStudyConverter:
                     treated_components.append(component_value.replace(" ", "_"))
 
                 connections.append(
-                    InputPortConnections(
+                    PortConnectionsSchema(
                         component1=treated_components[0],
                         port1=connection.port1,
                         component2=treated_components[1],
@@ -298,11 +296,11 @@ class AntaresStudyConverter:
         conversion_template: ConversionTemplate,
         virtual_objects: VirtualObjectsRepository = VirtualObjectsRepository(),
     ) -> tuple[
-        list[InputComponent], list[InputPortConnections], list[InputAreaConnections]
+        list[ComponentSchema], list[PortConnectionsSchema], list[AreaConnectionsSchema]
     ]:
-        components: list[InputComponent] = []
-        connections: list[InputPortConnections] = []
-        area_connections: list[InputAreaConnections] = []
+        components: list[ComponentSchema] = []
+        connections: list[PortConnectionsSchema] = []
+        area_connections: list[AreaConnectionsSchema] = []
 
         model_area_pattern = f"${{{conversion_template.template_parameters[0].name}}}"
 
@@ -458,9 +456,9 @@ class AntaresStudyConverter:
         self,
         conversion_template: ConversionTemplate,
         virtual_objects: VirtualObjectsRepository,
-        components: list[InputComponent],
-        connections: list[InputPortConnections],
-        area_connections: list[InputAreaConnections],
+        components: list[ComponentSchema],
+        connections: list[PortConnectionsSchema],
+        area_connections: list[AreaConnectionsSchema],
     ) -> None:
         self.logger.info(
             f"Converting components of model {conversion_template.name}..."
@@ -476,16 +474,16 @@ class AntaresStudyConverter:
         connections.extend(connections_from_model)
         area_connections.extend(area_connections_from_model)
 
-    def convert_study_to_input_system(self) -> InputSystem:
+    def convert_study_to_input_system(self) -> SystemSchema:
         self._copy_libs_to_model_librairies()
         self._copy_scenario_builder()
         self._create_dataseries_dir()
         model_conversion_templates = self._build_model_conversion_templates()
         self._check_converted_models_are_in_libs(model_conversion_templates)
         virtual_objects = self._build_virtual_objects_repo(model_conversion_templates)
-        components: list[InputComponent] = []
-        connections: list[InputPortConnections] = []
-        area_connections: list[InputAreaConnections] = []
+        components: list[ComponentSchema] = []
+        connections: list[PortConnectionsSchema] = []
+        area_connections: list[AreaConnectionsSchema] = []
         for model in self.models_to_convert:
             conversion_template = model_conversion_templates[model]
             self._convert_single_model(
@@ -503,14 +501,14 @@ class AntaresStudyConverter:
                     ANTARES_HISTORIC_LIB_ID, virtual_objects.areas
                 )
             )
-        system = InputSystem(
+        system = SystemSchema(
             id=self.study.name,
             components=components,
             connections=connections or None,
             area_connections=area_connections or None,
         )
         data = system.model_dump(exclude_none=True)
-        return InputSystem(**data)
+        return SystemSchema(**data)
 
     def _build_model_conversion_templates(self) -> dict[str, ConversionTemplate]:
         model_conversion_templates: dict[str, ConversionTemplate] = {}

--- a/src/antares_gems_converter/input_converter/src/converter.py
+++ b/src/antares_gems_converter/input_converter/src/converter.py
@@ -166,14 +166,10 @@ class AntaresStudyConverter:
                         id = legacy_component.binding_constraint_id
                     else:
                         continue
-                    obj = getattr(self.study, STUDY_LEVEL_GET[legacy_component.type])()[
-                        id
-                    ]
-                    arg = (
-                        [obj] if legacy_component.type == "binding_constraint" else obj
-                    )
                     getattr(self.study, STUDY_LEVEL_DELETION[legacy_component.type])(
-                        arg
+                        getattr(self.study, STUDY_LEVEL_GET[legacy_component.type])()[
+                            id
+                        ]
                     )
                 elif (
                     legacy_component.type in TEMPLATE_CLUSTER_TYPE_TO_DELETE_METHOD

--- a/src/antares_gems_converter/input_converter/src/converter.py
+++ b/src/antares_gems_converter/input_converter/src/converter.py
@@ -166,9 +166,15 @@ class AntaresStudyConverter:
                         id = legacy_component.binding_constraint_id
                     else:
                         continue
-                    obj = getattr(self.study, STUDY_LEVEL_GET[legacy_component.type])()[id]
-                    arg = [obj] if legacy_component.type == "binding_constraint" else obj
-                    getattr(self.study, STUDY_LEVEL_DELETION[legacy_component.type])(arg)
+                    obj = getattr(self.study, STUDY_LEVEL_GET[legacy_component.type])()[
+                        id
+                    ]
+                    arg = (
+                        [obj] if legacy_component.type == "binding_constraint" else obj
+                    )
+                    getattr(self.study, STUDY_LEVEL_DELETION[legacy_component.type])(
+                        arg
+                    )
                 elif (
                     legacy_component.type in TEMPLATE_CLUSTER_TYPE_TO_DELETE_METHOD
                     and legacy_component.area is not None

--- a/tests/input_converter/test_converter.py
+++ b/tests/input_converter/test_converter.py
@@ -31,11 +31,11 @@ from antares_gems_converter.input_converter.src.utils import (
 )
 from gems.model.resolve_library import resolve_library
 from gems.study.parsing import (
-    InputAreaConnections,
-    InputComponent,
-    InputComponentParameter,
-    InputPortConnections,
-    InputSystem,
+    AreaConnectionsSchema,
+    ComponentParameterSchema,
+    ComponentSchema,
+    PortConnectionsSchema,
+    SystemSchema,
     parse_yaml_components,
 )
 from gems.study.resolve_components import resolve_system
@@ -109,22 +109,22 @@ class TestConverter:
         converter = self._init_converter_from_study(local_study_w_areas, model_list=[])
         input_study = converter.convert_study_to_input_system()
 
-        expected_input_study = InputSystem(
+        expected_input_study = SystemSchema(
             id="studyTest",
             components=[
-                InputComponent(
+                ComponentSchema(
                     id="fr",
                     model="antares_legacy_models.area",
                     scenario_group=None,
                     parameters=[
-                        InputComponentParameter(
+                        ComponentParameterSchema(
                             id="ens_cost",
                             time_dependent=False,
                             scenario_dependent=False,
                             scenario_group=None,
                             value=0.5,
                         ),
-                        InputComponentParameter(
+                        ComponentParameterSchema(
                             id="spillage_cost",
                             time_dependent=False,
                             scenario_dependent=False,
@@ -133,19 +133,19 @@ class TestConverter:
                         ),
                     ],
                 ),
-                InputComponent(
+                ComponentSchema(
                     id="it",
                     model="antares_legacy_models.area",
                     scenario_group=None,
                     parameters=[
-                        InputComponentParameter(
+                        ComponentParameterSchema(
                             id="ens_cost",
                             time_dependent=False,
                             scenario_dependent=False,
                             scenario_group=None,
                             value=0.5,
                         ),
-                        InputComponentParameter(
+                        ComponentParameterSchema(
                             id="spillage_cost",
                             time_dependent=False,
                             scenario_dependent=False,
@@ -163,18 +163,18 @@ class TestConverter:
         area_components = converter._convert_area_to_component_list(lib_id)
 
         expected_area_components = [
-            InputComponent(
+            ComponentSchema(
                 id="fr",
                 model="antares_legacy_models.area",
                 parameters=[
-                    InputComponentParameter(
+                    ComponentParameterSchema(
                         id="ens_cost",
                         time_dependent=False,
                         scenario_dependent=False,
                         scenario_group=None,
                         value=0.5,
                     ),
-                    InputComponentParameter(
+                    ComponentParameterSchema(
                         id="spillage_cost",
                         time_dependent=False,
                         scenario_dependent=False,
@@ -183,18 +183,18 @@ class TestConverter:
                     ),
                 ],
             ),
-            InputComponent(
+            ComponentSchema(
                 id="it",
                 model="antares_legacy_models.area",
                 parameters=[
-                    InputComponentParameter(
+                    ComponentParameterSchema(
                         id="ens_cost",
                         time_dependent=False,
                         scenario_dependent=False,
                         scenario_group=None,
                         value=0.5,
                     ),
-                    InputComponentParameter(
+                    ComponentParameterSchema(
                         id="spillage_cost",
                         time_dependent=False,
                         scenario_dependent=False,
@@ -210,7 +210,7 @@ class TestConverter:
     def test_convert_area_to_yaml(self, local_study_w_areas: Study, lib_id: str):
         converter = self._init_converter_from_study(local_study_w_areas, model_list=[])
         area_components = converter._convert_area_to_component_list(lib_id)
-        input_study = InputSystem(id=converter.study.name, components=area_components)
+        input_study = SystemSchema(id=converter.study.name, components=area_components)
 
         # Dump model into yaml file
         yaml_path = converter.output_folder / "study_path.yaml"
@@ -219,22 +219,22 @@ class TestConverter:
         with open(yaml_path, "r", encoding="utf-8") as yaml_file:
             validated_data = parse_yaml_components(yaml_file)
 
-        expected_validated_data = InputSystem(
+        expected_validated_data = SystemSchema(
             id="studyTest",
             components=[
-                InputComponent(
+                ComponentSchema(
                     id="it",
                     model="antares_legacy_models.area",
                     scenario_group=None,
                     parameters=[
-                        InputComponentParameter(
+                        ComponentParameterSchema(
                             id="ens_cost",
                             time_dependent=False,
                             scenario_dependent=False,
                             scenario_group=None,
                             value=0.5,
                         ),
-                        InputComponentParameter(
+                        ComponentParameterSchema(
                             id="spillage_cost",
                             time_dependent=False,
                             scenario_dependent=False,
@@ -243,19 +243,19 @@ class TestConverter:
                         ),
                     ],
                 ),
-                InputComponent(
+                ComponentSchema(
                     id="fr",
                     model="antares_legacy_models.area",
                     scenario_group=None,
                     parameters=[
-                        InputComponentParameter(
+                        ComponentParameterSchema(
                             id="ens_cost",
                             time_dependent=False,
                             scenario_dependent=False,
                             scenario_group=None,
                             value=0.5,
                         ),
-                        InputComponentParameter(
+                        ComponentParameterSchema(
                             id="spillage_cost",
                             time_dependent=False,
                             scenario_dependent=False,
@@ -298,7 +298,7 @@ class TestConverter:
         cost_withdrawal_path = "cost_withdrawal_fr_storage_1"
         cost_level_path = "cost_level_fr_storage_1"
         expected_storage_connections = [
-            InputPortConnections(
+            PortConnectionsSchema(
                 component1="fr_storage_1",
                 port1="injection_port",
                 component2="fr",
@@ -306,103 +306,103 @@ class TestConverter:
             )
         ]
         expected_storage_component = [
-            InputComponent(
+            ComponentSchema(
                 id="fr_storage_1",
                 model=f"{lib_id}.short-term-storage",
                 scenario_group=None,
                 parameters=[
-                    InputComponentParameter(
+                    ComponentParameterSchema(
                         id="reservoir_capacity",
                         time_dependent=False,
                         scenario_dependent=False,
                         scenario_group=None,
                         value=0.0,
                     ),
-                    InputComponentParameter(
+                    ComponentParameterSchema(
                         id="injection_nominal_capacity",
                         time_dependent=False,
                         scenario_dependent=False,
                         scenario_group=None,
                         value=10.0,
                     ),
-                    InputComponentParameter(
+                    ComponentParameterSchema(
                         id="withdrawal_nominal_capacity",
                         time_dependent=False,
                         scenario_dependent=False,
                         scenario_group=None,
                         value=10.0,
                     ),
-                    InputComponentParameter(
+                    ComponentParameterSchema(
                         id="efficiency_injection",
                         time_dependent=False,
                         scenario_dependent=False,
                         scenario_group=None,
                         value=1,
                     ),
-                    InputComponentParameter(
+                    ComponentParameterSchema(
                         id="efficiency_withdrawal",
                         time_dependent=False,
                         scenario_dependent=False,
                         scenario_group=None,
                         value=1,
                     ),
-                    InputComponentParameter(
+                    ComponentParameterSchema(
                         id="lower_rule_curve",
                         time_dependent=True,
                         scenario_dependent=True,
                         scenario_group=None,
                         value=f"{lower_rule_curve_path}",
                     ),
-                    InputComponentParameter(
+                    ComponentParameterSchema(
                         id="upper_rule_curve",
                         time_dependent=True,
                         scenario_dependent=True,
                         scenario_group=None,
                         value=f"{upper_rule_curve_path}",
                     ),
-                    InputComponentParameter(
+                    ComponentParameterSchema(
                         id="p_max_injection_modulation",
                         time_dependent=True,
                         scenario_dependent=True,
                         scenario_group=None,
                         value=f"{pmax_injection_path}",
                     ),
-                    InputComponentParameter(
+                    ComponentParameterSchema(
                         id="p_max_withdrawal_modulation",
                         time_dependent=True,
                         scenario_dependent=True,
                         scenario_group=None,
                         value=f"{pmax_withdrawal_path}",
                     ),
-                    InputComponentParameter(
+                    ComponentParameterSchema(
                         id="inflows",
                         time_dependent=True,
                         scenario_dependent=True,
                         scenario_group=None,
                         value=f"{inflows_path}",
                     ),
-                    InputComponentParameter(
+                    ComponentParameterSchema(
                         id="initial_level",
                         time_dependent=False,
                         scenario_dependent=False,
                         scenario_group=None,
                         value=0.5,
                     ),
-                    InputComponentParameter(
+                    ComponentParameterSchema(
                         id="cost_injection",
                         time_dependent=True,
                         scenario_dependent=True,
                         scenario_group=None,
                         value=f"{cost_injection_path}",
                     ),
-                    InputComponentParameter(
+                    ComponentParameterSchema(
                         id="cost_withdrawal",
                         time_dependent=True,
                         scenario_dependent=True,
                         scenario_group=None,
                         value=f"{cost_withdrawal_path}",
                     ),
-                    InputComponentParameter(
+                    ComponentParameterSchema(
                         id="cost_level",
                         time_dependent=True,
                         scenario_dependent=True,
@@ -444,7 +444,7 @@ class TestConverter:
         # series_path = study_path / "input" / "thermal" / "series" / "fr" / "gaz"
         print(thermals_components)
         expected_thermals_connections = [
-            InputPortConnections(
+            PortConnectionsSchema(
                 component1="fr_gaz",
                 port1="balance_port",
                 component2="fr",
@@ -452,82 +452,82 @@ class TestConverter:
             )
         ]
         expected_thermals_components = [
-            InputComponent(
+            ComponentSchema(
                 id="fr_gaz",
                 model="antares_legacy_models.thermal",
                 scenario_group=None,
                 parameters=[
-                    InputComponentParameter(
+                    ComponentParameterSchema(
                         id="minimum_generation_modulation",
                         time_dependent=True,
                         scenario_dependent=True,
                         scenario_group=None,
                         value="minimum_generation_modulation_fr_gaz",
                     ),
-                    InputComponentParameter(
+                    ComponentParameterSchema(
                         id="p_max_cluster",
                         time_dependent=True,
                         scenario_dependent=True,
                         scenario_group=None,
                         value="p_max_cluster_fr_gaz",
                     ),
-                    InputComponentParameter(
+                    ComponentParameterSchema(
                         id="p_min_unit",
                         time_dependent=False,
                         scenario_dependent=False,
                         scenario_group=None,
                         value=0.0,
                     ),
-                    InputComponentParameter(
+                    ComponentParameterSchema(
                         id="p_max_unit",
                         time_dependent=False,
                         scenario_dependent=False,
                         scenario_group=None,
                         value=2.0,
                     ),
-                    InputComponentParameter(
+                    ComponentParameterSchema(
                         id="generation_cost",
                         time_dependent=False,
                         scenario_dependent=False,
                         scenario_group=None,
                         value=0.0,
                     ),
-                    InputComponentParameter(
+                    ComponentParameterSchema(
                         id="startup_cost",
                         time_dependent=False,
                         scenario_dependent=False,
                         scenario_group=None,
                         value=0.0,
                     ),
-                    InputComponentParameter(
+                    ComponentParameterSchema(
                         id="fixed_cost",
                         time_dependent=False,
                         scenario_dependent=False,
                         scenario_group=None,
                         value=0.0,
                     ),
-                    InputComponentParameter(
+                    ComponentParameterSchema(
                         id="d_min_up",
                         time_dependent=False,
                         scenario_dependent=False,
                         scenario_group=None,
                         value=1.0,
                     ),
-                    InputComponentParameter(
+                    ComponentParameterSchema(
                         id="d_min_down",
                         time_dependent=False,
                         scenario_dependent=False,
                         scenario_group=None,
                         value=1.0,
                     ),
-                    InputComponentParameter(
+                    ComponentParameterSchema(
                         id="unit_count",
                         time_dependent=False,
                         scenario_dependent=False,
                         scenario_group=None,
                         value=1.0,
                     ),
-                    InputComponentParameter(
+                    ComponentParameterSchema(
                         id="spinning",
                         time_dependent=False,
                         scenario_dependent=False,
@@ -570,7 +570,7 @@ class TestConverter:
 
         ### Compare connections
         connection = load_connections[0]
-        expected_connection: InputPortConnections = InputPortConnections(
+        expected_connection: PortConnectionsSchema = PortConnectionsSchema(
             **next(
                 (
                     connection
@@ -641,33 +641,33 @@ class TestConverter:
             (conn for conn in solar_connections if conn.component1 == "solar_fr"), None
         )
         solar_timeseries = "generation_fr"
-        expected_solar_connection = InputPortConnections(
+        expected_solar_connection = PortConnectionsSchema(
             component1="solar_fr",
             port1="balance_port",
             component2="fr",
             port2="balance_port",
         )
 
-        expected_solar_components = InputComponent(
+        expected_solar_components = ComponentSchema(
             id="solar_fr",
             model="antares_legacy_models.renewable",
             scenario_group=None,
             parameters=[
-                InputComponentParameter(
+                ComponentParameterSchema(
                     id="nominal_capacity",
                     time_dependent=False,
                     scenario_dependent=False,
                     value=1.0,
                     scenario_group=None,
                 ),
-                InputComponentParameter(
+                ComponentParameterSchema(
                     id="unit_count",
                     time_dependent=False,
                     scenario_dependent=False,
                     value=1.0,
                     scenario_group=None,
                 ),
-                InputComponentParameter(
+                ComponentParameterSchema(
                     id="generation",
                     time_dependent=True,
                     scenario_dependent=True,
@@ -699,18 +699,18 @@ class TestConverter:
         )
 
         load_timeseries = "load_fr"
-        expected_load_connection = InputPortConnections(
+        expected_load_connection = PortConnectionsSchema(
             component1="load_fr",
             port1="balance_port",
             component2="fr",
             port2="balance_port",
         )
-        expected_load_components = InputComponent(
+        expected_load_components = ComponentSchema(
             id="load_fr",
             model="antares_legacy_models.load",
             scenario_group=None,
             parameters=[
-                InputComponentParameter(
+                ComponentParameterSchema(
                     id="load",
                     time_dependent=True,
                     scenario_dependent=True,
@@ -747,30 +747,30 @@ class TestConverter:
             (conn for conn in wind_connections if conn.component1 == "wind_fr"), None
         )
 
-        expected_wind_connection = InputPortConnections(
+        expected_wind_connection = PortConnectionsSchema(
             component1="wind_fr",
             port1="balance_port",
             component2="fr",
             port2="balance_port",
         )
-        expected_wind_components = InputComponent(
+        expected_wind_components = ComponentSchema(
             id="wind_fr",
             model="antares_legacy_models.renewable",
             scenario_group="wind_group",
             parameters=[
-                InputComponentParameter(
+                ComponentParameterSchema(
                     id="nominal_capacity",
                     time_dependent=False,
                     scenario_dependent=False,
                     value=1.0,
                 ),
-                InputComponentParameter(
+                ComponentParameterSchema(
                     id="unit_count",
                     time_dependent=False,
                     scenario_dependent=False,
                     value=1.0,
                 ),
-                InputComponentParameter(
+                ComponentParameterSchema(
                     id="generation",
                     time_dependent=True,
                     scenario_dependent=True,
@@ -855,33 +855,33 @@ class TestConverter:
         at_it_direct_costs_timeseries = "hurdle_cost_direct_at_it"
         at_it_indirect_costs_timeseries = "hurdle_cost_indirect_at_it"
         expected_link_component = [
-            InputComponent(
+            ComponentSchema(
                 id="fr_/_it",
                 model="antares_legacy_models.link",
                 scenario_group=None,
                 parameters=[
-                    InputComponentParameter(
+                    ComponentParameterSchema(
                         id="capacity_direct",
                         time_dependent=True,
                         scenario_dependent=True,
                         scenario_group=None,
                         value=f"{fr_it_direct_links_timeseries}",
                     ),
-                    InputComponentParameter(
+                    ComponentParameterSchema(
                         id="capacity_indirect",
                         time_dependent=True,
                         scenario_dependent=True,
                         scenario_group=None,
                         value=f"{fr_it_indirect_links_timeseries}",
                     ),
-                    InputComponentParameter(
+                    ComponentParameterSchema(
                         id="hurdle_cost_direct",
                         time_dependent=True,
                         scenario_dependent=False,
                         scenario_group=None,
                         value=f"{fr_it_direct_costs_timeseries}",
                     ),
-                    InputComponentParameter(
+                    ComponentParameterSchema(
                         id="hurdle_cost_indirect",
                         time_dependent=True,
                         scenario_dependent=False,
@@ -890,33 +890,33 @@ class TestConverter:
                     ),
                 ],
             ),
-            InputComponent(
+            ComponentSchema(
                 id="at_/_fr",
                 model="antares_legacy_models.link",
                 scenario_group=None,
                 parameters=[
-                    InputComponentParameter(
+                    ComponentParameterSchema(
                         id="capacity_direct",
                         time_dependent=True,
                         scenario_dependent=True,
                         scenario_group=None,
                         value=f"{at_fr_direct_links_timeseries}",
                     ),
-                    InputComponentParameter(
+                    ComponentParameterSchema(
                         id="capacity_indirect",
                         time_dependent=True,
                         scenario_dependent=True,
                         scenario_group=None,
                         value=f"{at_fr_indirect_links_timeseries}",
                     ),
-                    InputComponentParameter(
+                    ComponentParameterSchema(
                         id="hurdle_cost_direct",
                         time_dependent=True,
                         scenario_dependent=False,
                         scenario_group=None,
                         value=f"{at_fr_direct_costs_timeseries}",
                     ),
-                    InputComponentParameter(
+                    ComponentParameterSchema(
                         id="hurdle_cost_indirect",
                         time_dependent=True,
                         scenario_dependent=False,
@@ -925,33 +925,33 @@ class TestConverter:
                     ),
                 ],
             ),
-            InputComponent(
+            ComponentSchema(
                 id="at_/_it",
                 model="antares_legacy_models.link",
                 scenario_group=None,
                 parameters=[
-                    InputComponentParameter(
+                    ComponentParameterSchema(
                         id="capacity_direct",
                         time_dependent=True,
                         scenario_dependent=True,
                         scenario_group=None,
                         value=f"{at_it_direct_links_timeseries}",
                     ),
-                    InputComponentParameter(
+                    ComponentParameterSchema(
                         id="capacity_indirect",
                         time_dependent=True,
                         scenario_dependent=True,
                         scenario_group=None,
                         value=f"{at_it_indirect_links_timeseries}",
                     ),
-                    InputComponentParameter(
+                    ComponentParameterSchema(
                         id="hurdle_cost_direct",
                         time_dependent=True,
                         scenario_dependent=False,
                         scenario_group=None,
                         value=f"{at_it_direct_costs_timeseries}",
                     ),
-                    InputComponentParameter(
+                    ComponentParameterSchema(
                         id="hurdle_cost_indirect",
                         time_dependent=True,
                         scenario_dependent=False,
@@ -963,37 +963,37 @@ class TestConverter:
         ]
 
         expected_link_connections = [
-            InputPortConnections(
+            PortConnectionsSchema(
                 component1="at_/_fr",
                 port1="in_port",
                 component2="at",
                 port2="balance_port",
             ),
-            InputPortConnections(
+            PortConnectionsSchema(
                 component1="at_/_fr",
                 port1="out_port",
                 component2="fr",
                 port2="balance_port",
             ),
-            InputPortConnections(
+            PortConnectionsSchema(
                 component1="at_/_it",
                 port1="in_port",
                 component2="at",
                 port2="balance_port",
             ),
-            InputPortConnections(
+            PortConnectionsSchema(
                 component1="at_/_it",
                 port1="out_port",
                 component2="it",
                 port2="balance_port",
             ),
-            InputPortConnections(
+            PortConnectionsSchema(
                 component1="fr_/_it",
                 port1="in_port",
                 component2="fr",
                 port2="balance_port",
             ),
-            InputPortConnections(
+            PortConnectionsSchema(
                 component1="fr_/_it",
                 port1="out_port",
                 component2="it",
@@ -1060,7 +1060,7 @@ class TestConverter:
         assert area_connections == []
         # Compare connections
 
-        expected_connection: InputPortConnections = InputPortConnections(
+        expected_connection: PortConnectionsSchema = PortConnectionsSchema(
             **next(
                 (
                     connection
@@ -1163,7 +1163,7 @@ class TestConverter:
         assert check_file_exists(path4)
         ### Compare area connections
         expected_area_connections = [
-            InputAreaConnections(
+            AreaConnectionsSchema(
                 component="battery_fr", port="injection_port", area="fr"
             )
         ]


### PR DESCRIPTION

## Process ID : [A2G-04] Changes due to GemsPy evolution


## Description

Upgrade of GemsPy -> v.0.1.0

GemsPy 0.1.0 massively refactored the public API: the Input* classes in gems.study.parsing were renamed to *Schema variants.


## Impact Analysis

- Replace InputSystem/InputComponent/InputComponentParameter/ InputPortConnections/InputAreaConnections with SystemSchema/ ComponentSchema/ComponentParameterSchema/PortConnectionsSchema/ AreaConnectionsSchema in converter.py and test_converter.py
- Pin gemspy==0.1.0 in requirements.in, requirements.txt, requirements-dev.txt, and pyproject.toml; regenerate requirements.txt (removes ortools/pypsa deps, adds linopy)
- Handle FileNotFoundError in _delete_legacy_objects for the case where a parent area deletion already removed thermal series directories
- Bump converter version to 0.1.0 and update COMPATIBILITY.md

Closes #44

## Checklist

- [x] Solver equivalence tests pass (`pytest tests/antares_historic/`)
- [x] `pyproject.toml` version bumped if converter logic changed
- [x] Changelog entry added if library changed (`CHANGELOG-antares_legacy_models_library.md`)
- [x] `COMPATIBILITY.md` updated if supported versions changed
- [x] Documentation updated or confirmed up to date
- [x] `AGENTS.md` reviewed for impact and updated if needed (file does not exist in the repo — no action required)
