### PR TITLE
(PR2) Update: Antares Simulator v10.0.0 to v10.1.0 and Antares Craft v0.3.0 to v0.14.0

### DIFF
--- a/dependencies.json
+++ b/dependencies.json
@@ -1,3 +1,3 @@
 {
-  "antares_simulator_version": "10.0.0"
+  "antares_simulator_version": "10.1.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "numpy",
     "PyYAML>=6.0",
     "pydantic",
-    "antares_craft>=0.14.0",
+    "antares_craft==0.14.0",
     "pandas",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "numpy",
     "PyYAML>=6.0",
     "pydantic",
-    "antares_craft>=0.3",
+    "antares_craft>=0.14.0",
     "pandas",
 ]
 

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,6 @@
 numpy
 PyYAML~=6.0.1
 pydantic
-antares_craft>=0.3
+antares_craft>=0.14.0
 pandas
 gemspy==0.1.0

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,6 @@
 numpy
 PyYAML~=6.0.1
 pydantic
-antares_craft>=0.14.0
+antares_craft==0.14.0
 pandas
 gemspy==0.1.0


### PR DESCRIPTION
## CHORE PR 

[Issue Antares Simulator](https://github.com/AntaresSimulatorTeam/AntaresLegacyModels-to-GEMS-Converter/issues/48)

[Issue Antares Craft](https://github.com/AntaresSimulatorTeam/AntaresLegacyModels-to-GEMS-Converter/issues/53)


### Description

This PR only support update of Antares Simulator and Antares Craft as dependency in the Converter repository, it does not include any new implementation or refactoring!

## Checklist

- [x] Github Workflow Pass

