### PR TITLE
Use generation instead of production

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,7 +154,7 @@ template:
 
 ## GEMS Model Libraries
 
-- **`antares_legacy_models.yml`** — Defines models for: `area`, `load`, `link`, `renewable`, `thermal`, `short_term_storage`. These mirror the implicit models in the Antares solver.
+- **`antares_legacy_models.yml`** — Defines models for: `area`, `load`, `link`, `renewable`, `thermal`, `short_term_storage`, `miscellaneous_generation`, `long_term_storage`. These mirror the implicit models in the Antares solver.
 - **`andromede_v1_models.yml`** — Defines models for: `battery`, `dsr`, `electrolyser`. These represent new modelling constructs not in the legacy solver.
 
 Both use the `flow` port-type with a single `flow` field for power balance connections.

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -4,6 +4,7 @@ This table maps converter versions to the tool versions they are compatible with
 
 | Converter | Antares-Simulator | antares-craft | GemsPy | Notes |
 |-----------|-------------------|---------------|--------|-------|
+| 0.1.1     | 10.1.0            | 0.14.0        | 0.1.0  | Added new models in Antares Legacy Models |
 | 0.1.0     | 10.1.0            | 0.14.0        | 0.1.0  | antares-craft 0.14.0 (numpy 2.x) GemsPy 0.1.0 (massive refactoring: rename Input* classes to *Schema) |
 | 0.0.1     | 10.0.0            | 0.3.0         | 0.0.2  | Initial release |
 
@@ -54,8 +55,8 @@ Runtime and development Python packages are pinned to exact versions in `pyproje
 
 | Component | Current Version | Version File |
 |-----------|----------------|--------------|
-| Converter | 0.1.0 | `pyproject.toml` |
-| Antares Legacy Models Library | 1.0.0 | `src/antares_gems_converter/libs/antares_historic/antares_legacy_models.yml` |
+| Converter | 0.1.1 | `pyproject.toml` |
+| Antares Legacy Models Library | 2.0.0 | `src/antares_gems_converter/libs/antares_historic/antares_legacy_models.yml` |
 | Antares-Simulator | 10.1.0 | `dependencies.json` |
 | antares-craft | 0.14.0 | `pyproject.toml` |
 | GemsPy | 0.1.0 | `pyproject.toml` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antares-legacy-gems-converter"
-version = "0.1.0"
+version = "0.1.1"
 description = "Convert Antares Legacy studies to GEMS format"
 license = {text = "MPL-2.0"}
 requires-python = ">=3.11"

--- a/src/antares_gems_converter/catalogs/antares_legacy_area_catalog.yml
+++ b/src/antares_gems_converter/catalogs/antares_legacy_area_catalog.yml
@@ -14,10 +14,10 @@ catalog:
       - taxonomy-category: balance
         output-id: imbalance_cost
         location-ports: null 
-      - taxonomy-category: dispatchable_production
+      - taxonomy-category: dispatchable_generation
         output-id: prop_cost
         location-ports: balance_port
-      - taxonomy-category: dispatchable_production
+      - taxonomy-category: dispatchable_generation
         output-id: non_prop_cost
         location-ports: balance_port
     terms-operator: sum
@@ -26,10 +26,10 @@ catalog:
 
   - id: OP.COST
     terms:
-      - taxonomy-category: dispatchable_production
+      - taxonomy-category: dispatchable_generation
         output-id: prop_cost
         location-ports: balance_port
-      - taxonomy-category: dispatchable_production
+      - taxonomy-category: dispatchable_generation
         output-id: non_prop_cost
         location-ports: balance_port
     terms-operator: sum
@@ -45,7 +45,7 @@ catalog:
 
   - id: CO2.EMIS
     terms:
-      - taxonomy-category: dispatchable_production
+      - taxonomy-category: dispatchable_generation
         output-id: co2_emissions
         location-ports: balance_port
     terms-operator: sum
@@ -53,7 +53,7 @@ catalog:
   
   - id: NH3.EMIS
     terms:
-      - taxonomy-category: dispatchable_production
+      - taxonomy-category: dispatchable_generation
         output-id: nh3_emissions
         location-ports: balance_port
     terms-operator: sum
@@ -61,7 +61,7 @@ catalog:
   
   - id: SO2.EMIS
     terms:
-      - taxonomy-category: dispatchable_production
+      - taxonomy-category: dispatchable_generation
         output-id: so2_emissions
         location-ports: balance_port
     terms-operator: sum
@@ -69,7 +69,7 @@ catalog:
   
   - id: NOX.EMIS
     terms:
-      - taxonomy-category: dispatchable_production
+      - taxonomy-category: dispatchable_generation
         output-id: nox_emissions
         location-ports: balance_port
     terms-operator: sum
@@ -77,7 +77,7 @@ catalog:
   
   - id: PM2_5.EMIS
     terms:
-      - taxonomy-category: dispatchable_production
+      - taxonomy-category: dispatchable_generation
         output-id: pm2_5_emissions
         location-ports: balance_port
     terms-operator: sum
@@ -85,7 +85,7 @@ catalog:
   
   - id: PM5.EMIS
     terms:
-      - taxonomy-category: dispatchable_production
+      - taxonomy-category: dispatchable_generation
         output-id: pm5_emissions
         location-ports: balance_port
     terms-operator: sum
@@ -93,7 +93,7 @@ catalog:
   
   - id: PM10.EMIS
     terms:
-      - taxonomy-category: dispatchable_production
+      - taxonomy-category: dispatchable_generation
         output-id: pm10_emissions
         location-ports: balance_port
     terms-operator: sum
@@ -101,7 +101,7 @@ catalog:
   
   - id: NMVOC.EMIS
     terms:
-      - taxonomy-category: dispatchable_production
+      - taxonomy-category: dispatchable_generation
         output-id: nmvoc_emissions
         location-ports: balance_port
     terms-operator: sum
@@ -109,7 +109,7 @@ catalog:
 
   - id: OP1.EMIS
     terms:
-      - taxonomy-category: dispatchable_production
+      - taxonomy-category: dispatchable_generation
         output-id: op1_emissions
         location-ports: balance_port
     terms-operator: sum
@@ -117,7 +117,7 @@ catalog:
   
   - id: OP2.EMIS
     terms:
-      - taxonomy-category: dispatchable_production
+      - taxonomy-category: dispatchable_generation
         output-id: op2_emissions
         location-ports: balance_port
     terms-operator: sum
@@ -125,7 +125,7 @@ catalog:
   
   - id: OP3.EMIS
     terms:
-      - taxonomy-category: dispatchable_production
+      - taxonomy-category: dispatchable_generation
         output-id: op3_emissions
         location-ports: balance_port
     terms-operator: sum
@@ -133,7 +133,7 @@ catalog:
 
   - id: OP4.EMIS
     terms:
-      - taxonomy-category: dispatchable_production
+      - taxonomy-category: dispatchable_generation
         output-id: op4_emissions
         location-ports: balance_port
     terms-operator: sum
@@ -141,7 +141,7 @@ catalog:
   
   - id: OP5.EMIS
     terms:
-      - taxonomy-category: dispatchable_production
+      - taxonomy-category: dispatchable_generation
         output-id: op5_emissions
         location-ports: balance_port
     terms-operator: sum
@@ -160,10 +160,10 @@ catalog:
       - taxonomy-category: fatal_consumption
         output-id: actual_load
         location-ports: balance_port
-      - taxonomy-category: renewable_fatal_production
+      - taxonomy-category: renewable_fatal_generation
         output-id: minus_generation
         location-ports: balance_port
-      - taxonomy-category: miscellaneous_fatal_production
+      - taxonomy-category: miscellaneous_fatal_generation
         output-id: minus_generation
         location-ports: balance_port
     terms-operator: sum
@@ -171,7 +171,7 @@ catalog:
 
   - id: DTG.BY.TECHNOLOGY
     terms:
-      - taxonomy-category: dispatchable_production
+      - taxonomy-category: dispatchable_generation
         output-id: generation_power
         location-ports: balance_port
     terms-operator: sum
@@ -192,7 +192,7 @@ catalog:
 
   - id: RES.GENERATION
     terms:
-      - taxonomy-category: renewable_fatal_production
+      - taxonomy-category: renewable_fatal_generation
         output-id: generation_power
         location-ports: balance_port
     breakdown:
@@ -248,7 +248,7 @@ catalog:
 
   - id: NODU 
     terms:
-      - taxonomy-category: dispatchable_production
+      - taxonomy-category: dispatchable_generation
         output-id: actual_num_units_on
         location-ports: balance_port
     terms-operator: sum
@@ -256,7 +256,7 @@ catalog:
 
   - id: NP.COST 
     terms:
-      - taxonomy-category: dispatchable_production
+      - taxonomy-category: dispatchable_generation
         output-id: non_prop_cost
         location-ports: balance_port
     terms-operator: sum
@@ -264,7 +264,7 @@ catalog:
 
   - id: AVL.DTG
     terms:
-      - taxonomy-category: dispatchable_production
+      - taxonomy-category: dispatchable_generation
         output-id: cluster_availability
         location-ports: balance_port
     terms-operator: sum
@@ -272,7 +272,7 @@ catalog:
 
   - id: DTG.MRG
     terms:
-      - taxonomy-category: dispatchable_production
+      - taxonomy-category: dispatchable_generation
         output-id: up_margin
         location-ports: balance_port
     terms-operator: sum
@@ -304,7 +304,7 @@ catalog:
 
   - id: ROW.BAL
     terms:
-      - taxonomy-category: miscellaneous_fatal_production
+      - taxonomy-category: miscellaneous_fatal_generation
         output-id: generation_power
         location-ports: balance_port
     filter: 
@@ -314,7 +314,7 @@ catalog:
 
   - id: MISC.NDG 
     terms:
-      - taxonomy-category: miscellaneous_fatal_production
+      - taxonomy-category: miscellaneous_fatal_generation
         output-id: generation_power
         location-ports: balance_port
     filter: 
@@ -324,7 +324,7 @@ catalog:
   
   - id: PSP 
     terms:
-      - taxonomy-category: miscellaneous_fatal_production
+      - taxonomy-category: miscellaneous_fatal_generation
         output-id: generation_power
         location-ports: balance_port
     filter: 

--- a/src/antares_gems_converter/catalogs/antares_legacy_thermal_cluster_catalog.yml
+++ b/src/antares_gems_converter/catalogs/antares_legacy_thermal_cluster_catalog.yml
@@ -5,13 +5,13 @@ catalog:
   taxonomy: antares_legacy_taxonomy
 
   location:
-    taxonomy-category: dispatchable_production
+    taxonomy-category: dispatchable_generation
 
   metrics-definition: 
 
   - id: GENERATION
     terms:
-      - taxonomy-category: dispatchable_production
+      - taxonomy-category: dispatchable_generation
         output-id: generation_power
         location-ports: null
     terms-operator: sum
@@ -21,7 +21,7 @@ catalog:
 
   - id: MIN.GEN
     terms:
-      - taxonomy-category: dispatchable_production
+      - taxonomy-category: dispatchable_generation
         output-id: min_gen_power
         location-ports: null
     terms-operator: sum
@@ -31,7 +31,7 @@ catalog:
 
   - id: PROFIT
     terms:
-      - taxonomy-category: dispatchable_production
+      - taxonomy-category: dispatchable_generation
         output-id: profit 
         location-ports: null
     terms-operator: sum
@@ -41,7 +41,7 @@ catalog:
 
   - id: NODU
     terms:
-      - taxonomy-category: dispatchable_production
+      - taxonomy-category: dispatchable_generation
         output-id: actual_num_units_on
         location-ports: null
     terms-operator: sum
@@ -51,7 +51,7 @@ catalog:
 
   - id: NP.COST
     terms:
-      - taxonomy-category: dispatchable_production
+      - taxonomy-category: dispatchable_generation
         output-id: non_prop_cost
         location-ports: null
     terms-operator: sum

--- a/src/antares_gems_converter/libs/antares_historic/CHANGELOG-antares_legacy_models_library.md
+++ b/src/antares_gems_converter/libs/antares_historic/CHANGELOG-antares_legacy_models_library.md
@@ -10,13 +10,27 @@ Versioning follows the rules defined in `COMPATIBILITY.md`:
 
 ---
 
+## [1.1.1]
+
+Renamed taxonomy categories to use `generation` in place of `production`:
+
+- `dispatchable_production` → `dispatchable_generation`
+- `renewable_fatal_production` → `renewable_fatal_generation`
+- `miscellaneous_fatal_production` → `miscellaneous_fatal_generation`
+- Parent category `production` → `generation`
+
+Updated the `thermal`, `renewable`, and `miscellaneous_generation` models accordingly.
+Catalog files (`antares_legacy_area_catalog.yml`, `antares_legacy_thermal_cluster_catalog.yml`) and the taxonomy (`antares_legacy_taxonomy.yml`) updated consistently.
+
+---
+
 ## [1.1.0]
 
-Renaming to match naming conventions. 
+Renaming to match naming conventions.
 
 New extra-outputs to be able to reproduce legacy output metrics.
 
-New parameter on link model : loop flow. 
+New parameter on link model : loop flow.
 
 ---
 

--- a/src/antares_gems_converter/libs/antares_historic/CHANGELOG-antares_legacy_models_library.md
+++ b/src/antares_gems_converter/libs/antares_historic/CHANGELOG-antares_legacy_models_library.md
@@ -10,35 +10,30 @@ Versioning follows the rules defined in `COMPATIBILITY.md`:
 
 ---
 
-## [1.1.1]
+## [2.0.0]
 
-Renamed taxonomy categories to use `generation` in place of `production`:
-
-- `dispatchable_production` → `dispatchable_generation`
-- `renewable_fatal_production` → `renewable_fatal_generation`
-- `miscellaneous_fatal_production` → `miscellaneous_fatal_generation`
-- Parent category `production` → `generation`
-
-Updated the `thermal`, `renewable`, and `miscellaneous_generation` models accordingly.
-Catalog files (`antares_legacy_area_catalog.yml`, `antares_legacy_thermal_cluster_catalog.yml`) and the taxonomy (`antares_legacy_taxonomy.yml`) updated consistently.
+- Added models `miscellaneous_generation` and `long_term_storage`
+- Renamed taxonomy categories to use `generation` in place of `production`:
+    - `dispatchable_production` → `dispatchable_generation`
+    - `renewable_fatal_production` → `renewable_fatal_generation`
+    - `miscellaneous_fatal_production` → `miscellaneous_fatal_generation`
+    - Parent category `production` → `generation`
+- Updated the `thermal`, `renewable`, and `miscellaneous_generation` models accordingly.
+- Catalog files (`antares_legacy_area_catalog.yml`, `antares_legacy_thermal_cluster_catalog.yml`) and the taxonomy (`antares_legacy_taxonomy.yml`) updated consistently.
 
 ---
 
 ## [1.1.0]
 
-Renaming to match naming conventions.
-
-New extra-outputs to be able to reproduce legacy output metrics.
-
-New parameter on link model : loop flow.
+- Renaming to match naming conventions.
+- New extra-outputs to be able to reproduce legacy output metrics.
+- New parameter on link model : loop flow.
 
 ---
 
 ## [1.0.0] — 2026-04-19
 
-Initial baseline release.
-
-Supported model types: area, thermal, link, short-term storage (STS), load, renewables.
+- Initial baseline release.
+- Supported model types: area, thermal, link, short-term storage (STS), load, renewables.
 HYBRID and FULL conversion modes supported.
-
-Validated against Antares-Simulator 10.0.0, antares-craft 0.3.0, GemsPy 0.0.2.
+- Validated against Antares-Simulator 10.0.0, antares-craft 0.3.0, GemsPy 0.0.2.

--- a/src/antares_gems_converter/libs/antares_historic/antares_legacy_models.yml
+++ b/src/antares_gems_converter/libs/antares_historic/antares_legacy_models.yml
@@ -12,7 +12,7 @@
 library:
   id: antares_legacy_models
   description: Antares historic model library
-  version: "1.1.0"
+  version: "1.1.1"
   taxonomy: antares_legacy_taxonomy
 
   port-types:

--- a/src/antares_gems_converter/libs/antares_historic/antares_legacy_models.yml
+++ b/src/antares_gems_converter/libs/antares_historic/antares_legacy_models.yml
@@ -12,7 +12,7 @@
 library:
   id: antares_legacy_models
   description: Antares historic model library
-  version: "1.1.1"
+  version: "2.0.0"
   taxonomy: antares_legacy_taxonomy
 
   port-types:

--- a/src/antares_gems_converter/libs/antares_historic/antares_legacy_models.yml
+++ b/src/antares_gems_converter/libs/antares_historic/antares_legacy_models.yml
@@ -151,7 +151,7 @@ library:
           expression: loop_flow
 
     - id: renewable
-      taxonomy-category: renewable_fatal_production
+      taxonomy-category: renewable_fatal_generation
       parameters:
         - id: nominal_capacity
         - id: num_units
@@ -175,7 +175,7 @@ library:
         - id: technology
     
     - id: miscellaneous_generation
-      taxonomy-category: miscellaneous_fatal_production
+      taxonomy-category: miscellaneous_fatal_generation
       parameters:
         - id: available_power
           time-dependent: true
@@ -197,7 +197,7 @@ library:
         - id: technology
 
     - id: thermal
-      taxonomy-category: dispatchable_production
+      taxonomy-category: dispatchable_generation
       parameters:
         - id: cluster_min_gen_modulation # Timeseries used to define the minimum generation of the cluster by cluster_min_gen_modulation * num_units * max_power_per_unit, this cannot exceed the maximum generation power cluster_max_generation (after being increased by min_power_per_unit). 
           scenario-dependent: true

--- a/src/antares_gems_converter/taxonomies/antares_legacy_taxonomy.yml
+++ b/src/antares_gems_converter/taxonomies/antares_legacy_taxonomy.yml
@@ -29,12 +29,12 @@ taxonomy:
         - id: is_loss_of_load
         - id: is_near_loss_of_load
 
-    - id: production
+    - id: generation
       ports:
         - id: balance_port
 
-    - id: dispatchable_production
-      parent-category: production
+    - id: dispatchable_generation
+      parent-category: generation
       variables: 
         - id: generation_power
       extra-outputs:
@@ -63,19 +63,19 @@ taxonomy:
         - id: plant
 
     - id: fatal_generation
-      parent-category: production
+      parent-category: generation
       parameters:
         - id: available_power
       extra-outputs:
         - id: minus_generation
         - id: generation_power
     
-    - id: renewable_fatal_production
+    - id: renewable_fatal_generation
       parent-category: fatal_generation
       properties:
         - id: technology
 
-    - id: miscellaneous_fatal_production
+    - id: miscellaneous_fatal_generation
       parent-category: fatal_generation
       properties:
         - id: technology 

--- a/uv.lock
+++ b/uv.lock
@@ -38,7 +38,7 @@ wheels = [
 
 [[package]]
 name = "antares-legacy-gems-converter"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "antares-craft" },


### PR DESCRIPTION
## Process ID

<!-- Which governance process does this PR fall under? -->
<!-- A2G-01 | A2G-02 | A2G-03 | A2G-04 | N/A -->

**Process:** A2G-02

## Description

Synchronize naming across models and taxonomies

Library version major number is bumped because of two added models in a previous PR https://github.com/AntaresSimulatorTeam/AntaresLegacyModels-to-GEMS-Converter/pull/43, where library update has been forgotten

## Impact Analysis
No impact, only changes in taxonomy

## Checklist

- [x] Solver equivalence tests pass (`pytest tests/antares_historic/`)
- [x] `pyproject.toml` version bumped if converter logic changed
- [x] Changelog entry added if library changed (`CHANGELOG-antares_legacy_models_library.md`)
- [x] `COMPATIBILITY.md` updated if supported versions changed
- [x] Documentation updated or confirmed up to date
- [x] `AGENTS.md` reviewed for impact and updated if needed