### PR TITLE
fix(ci): unify CI into a single job to avoid double environment install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,8 @@ on:
       - "**"
 
 jobs:
-  code-quality:
-    name: Code Quality
+  ci:
+    name: CI
     runs-on: ubuntu-22.04
 
     steps:
@@ -16,6 +16,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v6
@@ -31,9 +33,40 @@ jobs:
       - name: Check formatting
         run: uv run black --check --diff src/
 
-  tests:
-    name: Tests
-    needs: code-quality
-    uses: ./.github/workflows/run-tests.yml
-    with:
-      artifact_name: test-failures
+      - name: Resolve Antares version
+        id: resolve_version
+        run: |
+          VERSION=$(jq -r '.antares_simulator_version' dependencies.json)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Download Antares release
+        run: |
+          VERSION="${{ steps.resolve_version.outputs.version }}"
+          ARCHIVE="antares-${VERSION}-Ubuntu-22.04.tar.gz"
+          echo "Downloading Antares v${VERSION}..."
+          curl -L -f -o "${ARCHIVE}" \
+            "https://github.com/AntaresSimulatorTeam/Antares_Simulator/releases/download/v${VERSION}/${ARCHIVE}"
+
+      - name: Extract Antares binaries
+        run: |
+          VERSION="${{ steps.resolve_version.outputs.version }}"
+          tar -xzf "antares-${VERSION}-Ubuntu-22.04.tar.gz"
+
+      - name: Run tests
+        run: uv run pytest --cov=antares_gems_converter --cov=antares_runner --cov-report=xml -v --tb=short
+
+      - name: Upload test artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-failures
+          path: |
+            **/*.log
+          retention-days: 7
+
+      - name: Cleanup
+        if: always()
+        run: |
+          VERSION="${{ steps.resolve_version.outputs.version }}"
+          rm -f "antares-${VERSION}-Ubuntu-22.04.tar.gz"
+          rm -rf "antares-${VERSION}-Ubuntu-22.04"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,65 +8,7 @@ on:
 jobs:
   ci:
     name: CI
-    runs-on: ubuntu-22.04
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v6
-        with:
-          enable-cache: true
-
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-
-      - name: Install dependencies
-        run: uv sync --group dev
-
-      - name: Type checking
-        run: uv run mypy src/
-
-      - name: Check formatting
-        run: uv run black --check --diff src/
-
-      - name: Resolve Antares version
-        id: resolve_version
-        run: |
-          VERSION=$(jq -r '.antares_simulator_version' dependencies.json)
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-
-      - name: Download Antares release
-        run: |
-          VERSION="${{ steps.resolve_version.outputs.version }}"
-          ARCHIVE="antares-${VERSION}-Ubuntu-22.04.tar.gz"
-          echo "Downloading Antares v${VERSION}..."
-          curl -L -f -o "${ARCHIVE}" \
-            "https://github.com/AntaresSimulatorTeam/Antares_Simulator/releases/download/v${VERSION}/${ARCHIVE}"
-
-      - name: Extract Antares binaries
-        run: |
-          VERSION="${{ steps.resolve_version.outputs.version }}"
-          tar -xzf "antares-${VERSION}-Ubuntu-22.04.tar.gz"
-
-      - name: Run tests
-        run: uv run pytest --cov=antares_gems_converter --cov=antares_runner --cov-report=xml -v --tb=short
-
-      - name: Upload test artifacts on failure
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-failures
-          path: |
-            **/*.log
-          retention-days: 7
-
-      - name: Cleanup
-        if: always()
-        run: |
-          VERSION="${{ steps.resolve_version.outputs.version }}"
-          rm -f "antares-${VERSION}-Ubuntu-22.04.tar.gz"
-          rm -rf "antares-${VERSION}-Ubuntu-22.04"
+    uses: ./.github/workflows/run-tests.yml
+    with:
+      run_code_quality: true
+      artifact_name: test-failures

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -41,6 +41,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v6

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,6 +23,11 @@ on:
         required: false
         type: string
         default: 'test-failures'
+      run_code_quality:
+        description: 'Run mypy and black checks before tests'
+        required: false
+        type: boolean
+        default: false
     outputs:
       test_outcome:
         description: 'Outcome of the test run (success or failure)'
@@ -51,6 +56,14 @@ jobs:
 
       - name: Install dependencies
         run: uv sync --group dev
+
+      - name: Type checking
+        if: inputs.run_code_quality
+        run: uv run mypy src/
+
+      - name: Check formatting
+        if: inputs.run_code_quality
+        run: uv run black --check --diff src/
 
       - name: Override antares-craft version
         if: inputs.antares_craft_version != ''


### PR DESCRIPTION
## Summary

- **No code duplication**: `ci.yml` is now a thin 12-line caller of `run-tests.yml` — all logic lives in one place.
- **Single install**: the previous setup had two sequential jobs on separate runners (`code-quality` then `run-tests.yml`), causing a double `uv sync`. Now everything runs in one job, one install.
- **`run_code_quality` input added to `run-tests.yml`**: when `true`, mypy and black run after `uv sync` and before the test steps. Defaults to `false` so the 3 other callers (`check-gemspy-update`, `check-antares-craft-update`, `check-antares-update`) are unaffected.
- **uv caching**: `enable-cache: true` added to `setup-uv` in `run-tests.yml` for faster installs across all workflows.

## Test plan

- [ ] CI passes on this branch (code-quality + tests in the unified job via `run_code_quality: true`)
- [ ] Verify the other 3 workflows (`check-*`) still work correctly (they call `run-tests.yml` without `run_code_quality`, behaviour unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)