### PR TITLE
(PR5) Prepare application for first official release [A2G-02]

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,34 @@
+# Upload sdist and wheel to PyPI when a GitHub Release is published.
+# Configure a GitHub Environment named "PyPi" with secret PYPI_TOKEN (PyPI API token).
+
+name: Publish Python distributions to PyPI
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-22.04
+    environment: PyPi
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.11"
+
+      - name: Build sdist and wheel
+        run: uv build
+
+      - name: Publish to PyPI
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -27,12 +27,13 @@ pip install antares-legacy-gems-converter
 
 **From source (for development):**
 
+Requires [uv](https://docs.astral.sh/uv/). Python library versions are pinned in `pyproject.toml` and locked in `uv.lock` (see [COMPATIBILITY.md](COMPATIBILITY.md#python-library-dependencies)).
+
 ```bash
 git clone https://github.com/AntaresSimulatorTeam/AntaresLegacyModels-to-GEMS-Converter.git
 cd AntaresLegacyModels-to-GEMS-Converter
 uv sync --group dev
 ```
-
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,15 @@ This tool automates the translation of Antares Simulator studies into valid GEMS
 
 ## Installation
 
-Requires [uv](https://docs.astral.sh/uv/) and Python 3.11+ (CI uses 3.12). Python library versions are pinned in `pyproject.toml` and locked in `uv.lock` (see [COMPATIBILITY.md](COMPATIBILITY.md#python-library-dependencies)).
+Requires Python 3.11+.
+
+**From PyPI:**
+
+```bash
+pip install antares-legacy-gems-converter
+```
+
+**From source (for development):**
 
 ```bash
 git clone https://github.com/AntaresSimulatorTeam/AntaresLegacyModels-to-GEMS-Converter.git
@@ -48,9 +56,7 @@ model_list = thermal, battery
 Then run the converter:
 
 ```bash
-python -m antares_gems_converter.input_converter.src.main \
-    --conf path/to/config.ini \
-    --logging path/to/output.log
+antares-to-gems --conf path/to/config.ini --logging path/to/output.log
 ```
 
 The `--conf` and `--logging` arguments are optional — they default to `data/config.ini` and `data/logging.log` respectively.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,9 @@ dependencies = [
     "PyYAML>=6.0.3",
 ]
 
+[project.scripts]
+antares-to-gems = "antares_gems_converter.input_converter.src.main:main"
+
 [dependency-groups]
 dev = [
     "pytest>=9.0.3",

--- a/src/antares_gems_converter/input_converter/src/main.py
+++ b/src/antares_gems_converter/input_converter/src/main.py
@@ -117,8 +117,7 @@ def parse_commandline() -> Namespace:
     return parser.parse_args()
 
 
-if __name__ == "__main__":
-    config: dict = {}
+def main() -> None:
     args = parse_commandline()
     log_path = args.logging
     log_path.parent.mkdir(parents=True, exist_ok=True)
@@ -173,3 +172,7 @@ if __name__ == "__main__":
 
     converter = AntaresStudyConverter(**params)  # type: ignore
     converter.process_all()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## [A2G-02](https://github.com/AntaresSimulatorTeam/AntaresLegacyModels-to-GEMS-Converter/issues/67)

## Description
Adds PyPI publishing support and a proper CLI entry point to the AntaresLegacy Converter:
- `publish.yml` workflow triggers automatically on GitHub Release to build and push the package to PyPI
- `antares-to-gems` CLI command exposed via `[project.scripts]` in `pyproject.toml`
- `main()` function introduced in `main.py` as the callable entry point
- README updated with PyPI install instructions and the new `antares-to-gems` command

## Impact Analysis
No breaking changes. Existing `uv sync --group dev` + source workflow is unchanged. The new CLI command is additive.

## Checklist
- [ ] Tests pass
- [ ] `pyproject.toml` version bumped if converter logic changed
