### PR TITLE
(PR6) Prepare application for first official release 0.2.0 [A2G-02]

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,34 @@
+# Upload sdist and wheel to PyPI when a GitHub Release is published.
+# Configure a GitHub Environment named "PyPi" with secret PYPI_TOKEN (PyPI API token).
+
+name: Publish Python distributions to PyPI
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-22.04
+    environment: PyPi
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.11"
+
+      - name: Build sdist and wheel
+        run: uv build
+
+      - name: Publish to PyPI
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_TOKEN }}

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -1,0 +1,8 @@
+Github identifiers of authors, in alphabetical order:
+
+aoustry
+dusanparipovic
+nikolaredstork
+tbittar
+Juliette-Gerbaux
+

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -2,7 +2,7 @@ Github identifiers of authors, in alphabetical order:
 
 aoustry
 dusanparipovic
+Juliette-Gerbaux
 nikolaredstork
 tbittar
-Juliette-Gerbaux
 

--- a/README.md
+++ b/README.md
@@ -27,12 +27,13 @@ pip install antares-legacy-gems-converter
 
 **From source (for development):**
 
+Requires [uv](https://docs.astral.sh/uv/). Python library versions are pinned in `pyproject.toml` and locked in `uv.lock` (see [COMPATIBILITY.md](COMPATIBILITY.md#python-library-dependencies)).
+
 ```bash
 git clone https://github.com/AntaresSimulatorTeam/AntaresLegacyModels-to-GEMS-Converter.git
 cd AntaresLegacyModels-to-GEMS-Converter
 uv sync --group dev
 ```
-
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,15 @@ This tool automates the translation of Antares Simulator studies into valid GEMS
 
 ## Installation
 
-Requires [uv](https://docs.astral.sh/uv/) and Python 3.11+ (CI uses 3.12). Python library versions are pinned in `pyproject.toml` and locked in `uv.lock` (see [COMPATIBILITY.md](COMPATIBILITY.md#python-library-dependencies)).
+Requires Python 3.11+.
+
+**From PyPI:**
+
+```bash
+pip install antares-legacy-gems-converter
+```
+
+**From source (for development):**
 
 ```bash
 git clone https://github.com/AntaresSimulatorTeam/AntaresLegacyModels-to-GEMS-Converter.git
@@ -48,9 +56,7 @@ model_list = thermal, battery
 Then run the converter:
 
 ```bash
-python -m antares_gems_converter.input_converter.src.main \
-    --conf path/to/config.ini \
-    --logging path/to/output.log
+antares-to-gems --conf path/to/config.ini --logging path/to/output.log
 ```
 
 The `--conf` and `--logging` arguments are optional — they default to `data/config.ini` and `data/logging.log` respectively.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,15 @@ authors = [
     {name = "Juliette Gerbaux @Juliette-Gerbaux"}
 ]
 requires-python = ">=3.11"
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Science/Research",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering",
+    "Operating System :: OS Independent",
+]
 dependencies = [
     "antares_craft==0.14.0",
     "antares-study-version==1.0.20",
@@ -27,6 +36,9 @@ dependencies = [
     "gemspy==0.1.2",
     "PyYAML>=6.0.3",
 ]
+
+[project.urls]
+Issues = "https://github.com/AntaresSimulatorTeam/AntaresLegacyModels-to-GEMS-Converter/issues"
 
 [project.scripts]
 antares-to-gems = "antares_gems_converter.input_converter.src.main:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,9 @@ dependencies = [
     "PyYAML>=6.0.3",
 ]
 
+[project.scripts]
+antares-to-gems = "antares_gems_converter.input_converter.src.main:main"
+
 [dependency-groups]
 dev = [
     "pytest>=9.0.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,16 @@ build-backend = "setuptools.build_meta"
 name = "antares-legacy-gems-converter"
 version = "0.2.0"
 description = "Convert Antares Legacy studies to GEMS format"
-license = {text = "MPL-2.0"}
+readme = "README.md"
+license = "MPL-2.0"
+license-files = ["LICENSE"]
+authors = [
+    {name = "Antoine Oustry @aoustry"},
+    {name = "Dušan Paripović @dusanparipovic"},
+    {name = "Nikola Ilić @nikolaredstork"},
+    {name = "Thomas Bittar @tbittar"},
+    {name = "Juliette Gerbaux @Juliette-Gerbaux"}
+]
 requires-python = ">=3.11"
 dependencies = [
     "antares_craft==0.14.0",

--- a/src/antares_gems_converter/input_converter/src/main.py
+++ b/src/antares_gems_converter/input_converter/src/main.py
@@ -117,8 +117,7 @@ def parse_commandline() -> Namespace:
     return parser.parse_args()
 
 
-if __name__ == "__main__":
-    config: dict = {}
+def main() -> None:
     args = parse_commandline()
     log_path = args.logging
     log_path.parent.mkdir(parents=True, exist_ok=True)
@@ -173,3 +172,7 @@ if __name__ == "__main__":
 
     converter = AntaresStudyConverter(**params)  # type: ignore
     converter.process_all()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/antares_gems_converter/libs/antares_historic/antares_legacy_models.yml.sha256
+++ b/src/antares_gems_converter/libs/antares_historic/antares_legacy_models.yml.sha256
@@ -1,1 +1,1 @@
-19678a7b14cd7faa270dfa75ac3722dbc4cd34f8bcca7a66ede7f4e9cdfaf73c  antares_legacy_models.yml
+a5f5f02781e67bd146ba6c2cd464ac7c48906d1b068c3e58ff9c44cad1584fd1  antares_legacy_models.yml

--- a/src/antares_gems_converter/libs/antares_historic/antares_legacy_models.yml.sha256
+++ b/src/antares_gems_converter/libs/antares_historic/antares_legacy_models.yml.sha256
@@ -1,0 +1,1 @@
+19678a7b14cd7faa270dfa75ac3722dbc4cd34f8bcca7a66ede7f4e9cdfaf73c  antares_legacy_models.yml

--- a/src/antares_gems_converter/libs/reference_models/andromede_v1_models.yml.sha256
+++ b/src/antares_gems_converter/libs/reference_models/andromede_v1_models.yml.sha256
@@ -1,0 +1,1 @@
+5bbf2768d04d6ecf47aa28a2ffae78cf288f1b1ce9285c7d317ce7367b96dfd0  andromede_v1_models.yml

--- a/uv.lock
+++ b/uv.lock
@@ -38,7 +38,7 @@ wheels = [
 
 [[package]]
 name = "antares-legacy-gems-converter"
-version = "0.1.2"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "antares-craft" },


### PR DESCRIPTION
## [A2G-02](https://github.com/AntaresSimulatorTeam/AntaresLegacyModels-to-GEMS-Converter/issues/67)

## Description
Adds PyPI publishing support and a proper CLI entry point to the AntaresLegacy Converter:
- `publish.yml` workflow triggers automatically on GitHub Release to build and push the package to PyPI
- `antares-to-gems` CLI command exposed via `[project.scripts]` in `pyproject.toml`
- `main()` function introduced in `main.py` as the callable entry point
- README updated with PyPI install instructions and the new `antares-to-gems` command
- adds `AUTHORS.txt` file
- updates version number inside uv.lock file 
- updates `pyproject.toml` file e.g. add authors and GitHub names

## Impact Analysis
No breaking changes. Existing `uv sync --group dev` + source workflow is unchanged. The new CLI command is additive.

## Checklist
- [x] Tests pass
- [x] `pyproject.toml` version bumped
- [x] Documentation updated
- [x] Changelog entry added if library changed (`CHANGELOG-antares_legacy_models_library.md`)
- [x] `COMPATIBILITY.md` updated if supported versions changed
- [x] `AGENTS.md` reviewed for impact and updated if needed



