### PR TITLE
Naming conventions for component ids

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,6 +161,7 @@ template:
 - **Column indexing**: 0-based, references actual columns in Antares data matrices.
 - **Operations**: `divide_by` can reference another parameter by name (e.g., `divide_by: reservoir_capacity`).
 - **Electricity carrier assumption**: all current templates assume components belong to the electricity system (`carrier: electricity`). Multi-energy support would require revisiting this assumption in every template.
+- **Identifier naming** (components, parameters, properties): `snake_case`; qualifier first (adjective before noun); `is_` prefix for booleans; units in schema metadata, not names. Component IDs start with the area: `${area}_<detail>` (e.g. `${area}_node`, `${area}_hydro_storage`) — never `<detail>_${area}`. Abbreviations whitelist: `gen` (generation), `prop` (proportional), `abs` (absolute), `alg` (algebraic), `min` (minimum), `max` (maximum), `num` (number), pollutant codes (`co2`, `nh3`, `so2`, `nox`, `pm2_5`, `pm5`, `pm10`, `nmvoc`, `op1`–`op5`). Everything else spelled out in full.
 
 ---
 

--- a/src/antares_gems_converter/catalogs/antares_legacy_thermal_cluster_catalog.yml
+++ b/src/antares_gems_converter/catalogs/antares_legacy_thermal_cluster_catalog.yml
@@ -16,8 +16,6 @@ catalog:
         location-ports: null
     terms-operator: sum
     time-operator: sum
-    breakdown:
-      - key: plant
 
   - id: MIN.GEN
     terms:
@@ -26,8 +24,6 @@ catalog:
         location-ports: null
     terms-operator: sum
     time-operator: sum
-    breakdown:
-      - key: plant
 
   - id: PROFIT
     terms:
@@ -36,8 +32,6 @@ catalog:
         location-ports: null
     terms-operator: sum
     time-operator: sum
-    breakdown:
-      - key: plant
 
   - id: NODU
     terms:
@@ -46,8 +40,6 @@ catalog:
         location-ports: null
     terms-operator: sum
     time-operator: sum
-    breakdown:
-      - key: plant
 
   - id: NP.COST
     terms:
@@ -56,5 +48,3 @@ catalog:
         location-ports: null
     terms-operator: sum
     time-operator: sum
-    breakdown:
-      - key: plant

--- a/src/antares_gems_converter/input_converter/data/model_configuration/area.yaml
+++ b/src/antares_gems_converter/input_converter/data/model_configuration/area.yaml
@@ -20,7 +20,7 @@ template:
       description: "Area identifier"
 
   components:
-    - id: ${area}
+    - id: ${area}_node
       parameters:
         - id: unsupplied_energy_cost
           time-dependent: false

--- a/src/antares_gems_converter/input_converter/data/model_configuration/battery.yaml
+++ b/src/antares_gems_converter/input_converter/data/model_configuration/battery.yaml
@@ -38,7 +38,7 @@ template:
 
 
   components:
-    - id: battery_${area}
+    - id: ${area}_battery
       parameters:
         - id: reservoir_capacity
           time-dependent: false
@@ -151,14 +151,14 @@ template:
             constant: electricity
 
   connections:
-    - component1: battery_${area}
+    - component1: ${area}_battery
       port1: injection_port
-      component2: ${area}
+      component2: ${area}_node
       port2: balance_port
 
   area-connections: #Syntax for hybrid connections: https://antares-simulator.readthedocs.io/en/latest/user-guide/solver/08-hybrid-studies/
     #To handle the case of hybrid studies, where we replace complex modeling artifacts for batteries by a model.
-    - component: battery_${area}
+    - component: ${area}_battery
       port: injection_port
       area: ${area}
 

--- a/src/antares_gems_converter/input_converter/data/model_configuration/hydro.yaml
+++ b/src/antares_gems_converter/input_converter/data/model_configuration/hydro.yaml
@@ -21,7 +21,7 @@ template:
       # exclude:
 
   components:
-    - id: lt_storage_${area}
+    - id: ${area}_hydro_storage
       parameters:
         - id: reservoir_capacity
           time-dependent: false
@@ -115,14 +115,14 @@ template:
 
   # For full modeler mode
   connections:
-    - component1: lt_storage_${area}
+    - component1: ${area}_hydro_storage
       port1: balance_port
-      component2: ${area}
+      component2: ${area}_node
       port2: balance_port
 
   # For hybrid mode
   area-connections:
-    - component: lt_storage_${area}
+    - component: ${area}_hydro_storage
       port: balance_port
       area: ${area}
 

--- a/src/antares_gems_converter/input_converter/data/model_configuration/link.yaml
+++ b/src/antares_gems_converter/input_converter/data/model_configuration/link.yaml
@@ -21,7 +21,7 @@ template:
       #   # How to identify virtual links in Antares ?
 
   components:
-    - id: ${link} # How to specify that we want to get the link_id ?
+    - id: ${link}_link # How to specify that we want to get the link_id ?
       parameters:
         - id: direct_capacity
           time-dependent: true
@@ -74,23 +74,23 @@ template:
 
   # For full modeler mode
   connections:
-    - component1: ${link}
+    - component1: ${link}_link
       port1: in_port
-      component2: ${link}.area_from_id
+      component2: ${link}.area_from_id._node
       port2: balance_port
 
-    - component1: ${link}
+    - component1: ${link}_link
       port1: out_port
-      component2: ${link}.area_to_id
+      component2: ${link}.area_to_id._node
       port2: balance_port
 
   # For hybrid mode
   area-connections:
-    - component: ${link}
+    - component: ${link}_link
       port: in_port
       area: ${link}.area_from_id
 
-    - component: ${link}
+    - component: ${link}_link
       port: out_port
       area: ${link}.area_to_id
 

--- a/src/antares_gems_converter/input_converter/data/model_configuration/load.yaml
+++ b/src/antares_gems_converter/input_converter/data/model_configuration/load.yaml
@@ -21,7 +21,7 @@ template:
       # exclude:
 
   components:
-    - id: load_${area}
+    - id: ${area}_load
       parameters:
         - id: load
           time-dependent: true
@@ -37,14 +37,14 @@ template:
 
   # For full modeler mode
   connections:
-    - component1: load_${area}
+    - component1: ${area}_load
       port1: balance_port
-      component2: ${area}
+      component2: ${area}_node
       port2: balance_port
 
   # For hybrid mode
   area-connections:
-    - component: load_${area}
+    - component: ${area}_load
       port: balance_port
       area: ${area}
 

--- a/src/antares_gems_converter/input_converter/data/model_configuration/misc_gen.yaml
+++ b/src/antares_gems_converter/input_converter/data/model_configuration/misc_gen.yaml
@@ -19,7 +19,7 @@ template:
     - name: area
 
   components:
-    - id: chp_${area}
+    - id: ${area}_combined_heat_power
       parameters:
         - id: available_power
           time-dependent: true
@@ -35,11 +35,11 @@ template:
             constant: electricity
         - id: technology
           value:
-            constant: chp
+            constant: combined_heat_power
         - id: miscellaneous_type
           value:
             constant: misc_ndg
-    - id: biomass_${area}
+    - id: ${area}_biomass
       parameters:
         - id: available_power
           time-dependent: true
@@ -59,7 +59,7 @@ template:
         - id: miscellaneous_type
           value:
             constant: misc_ndg
-    - id: biogas_${area}
+    - id: ${area}_biogas
       parameters:
         - id: available_power
           time-dependent: true
@@ -79,7 +79,7 @@ template:
         - id: miscellaneous_type
           value:
             constant: misc_ndg
-    - id: waste_${area}
+    - id: ${area}_waste
       parameters:
         - id: available_power
           time-dependent: true
@@ -99,7 +99,7 @@ template:
         - id: miscellaneous_type
           value:
             constant: misc_ndg
-    - id: geothermal_${area}
+    - id: ${area}_geothermal
       parameters:
         - id: available_power
           time-dependent: true
@@ -119,7 +119,7 @@ template:
         - id: miscellaneous_type
           value:
             constant: misc_ndg
-    - id: other_${area}
+    - id: ${area}_other
       parameters:
         - id: available_power
           time-dependent: true
@@ -139,7 +139,7 @@ template:
         - id: miscellaneous_type
           value:
             constant: misc_ndg
-    - id: psp_${area}
+    - id: ${area}_pumped_storage_power
       parameters:
         - id: available_power
           time-dependent: true
@@ -155,11 +155,11 @@ template:
             constant: electricity
         - id: technology
           value:
-            constant: psp
+            constant: pumped_storage_power
         - id: miscellaneous_type
           value:
-            constant: psp
-    - id: rest_of_world_${area}
+            constant: pumped_storage_power
+    - id: ${area}_rest_world
       parameters:
         - id: available_power
           time-dependent: true
@@ -175,72 +175,72 @@ template:
             constant: electricity
         - id: technology
           value:
-            constant: rest_of_world
+            constant: rest_world
         - id: miscellaneous_type
           value:
-            constant: rest_of_world
+            constant: rest_world
 
   # For full modeler mode
   connections:
-    - component1: chp_${area}
+    - component1: ${area}_combined_heat_power
       port1: balance_port
-      component2: ${area}
+      component2: ${area}_node
       port2: balance_port
-    - component1: biomass_${area}
+    - component1: ${area}_biomass
       port1: balance_port
-      component2: ${area}
+      component2: ${area}_node
       port2: balance_port
-    - component1: biogas_${area}
+    - component1: ${area}_biogas
       port1: balance_port
-      component2: ${area}
+      component2: ${area}_node
       port2: balance_port
-    - component1: waste_${area}
+    - component1: ${area}_waste
       port1: balance_port
-      component2: ${area}
+      component2: ${area}_node
       port2: balance_port
-    - component1: geothermal_${area}
+    - component1: ${area}_geothermal
       port1: balance_port
-      component2: ${area}
+      component2: ${area}_node
       port2: balance_port
-    - component1: other_${area}
+    - component1: ${area}_other
       port1: balance_port
-      component2: ${area}
+      component2: ${area}_node
       port2: balance_port
-    - component1: psp_${area}
+    - component1: ${area}_pumped_storage_power
       port1: balance_port
-      component2: ${area}
+      component2: ${area}_node
       port2: balance_port
-    - component1: rest_of_world_${area}
+    - component1: ${area}_rest_world
       port1: balance_port
-      component2: ${area}
+      component2: ${area}_node
       port2: balance_port
 
   # For hybrid mode
   area-connections:
-    - component: chp_${area}
+    - component: ${area}_combined_heat_power
       port: balance_port
       area: ${area}
-    - component: biomass_${area}
+    - component: ${area}_biomass
       port: balance_port
       area: ${area}
-    - component: biogas_${area}
+    - component: ${area}_biogas
       port: balance_port
       area: ${area}
-    - component: waste_${area}
+    - component: ${area}_waste
       port: balance_port
       area: ${area}
-    - component: geothermal_${area}
+    - component: ${area}_geothermal
       port: balance_port
       area: ${area}
-    - component: other_${area}
+    - component: ${area}_other
       port: balance_port
       area: ${area}
-    - component: psp_${area}
+    - component: ${area}_pumped_storage_power
       port: balance_port
       area: ${area}
-    - component: rest_of_world_${area}
+    - component: ${area}_rest_world
       port: balance_port
-      area: ${area}    
+      area: ${area}
 
   legacy-objects-to-delete:
     - id: legacy_misc_gen

--- a/src/antares_gems_converter/input_converter/data/model_configuration/ror.yaml
+++ b/src/antares_gems_converter/input_converter/data/model_configuration/ror.yaml
@@ -21,7 +21,7 @@ template:
       # exclude:
 
   components:
-    - id: ror_${area}
+    - id: ${area}_run_of_river
       parameters:
         - id: nominal_capacity
           time-dependent: false
@@ -51,14 +51,14 @@ template:
 
   # For full modeler mode
   connections:
-    - component1: ror_${area}
+    - component1: ${area}_run_of_river
       port1: balance_port
-      component2: ${area}
+      component2: ${area}_node
       port2: balance_port
 
   # For hybrid mode
   area-connections:
-    - component: ror_${area}
+    - component: ${area}_run_of_river
       port: balance_port
       area: ${area}
 

--- a/src/antares_gems_converter/input_converter/data/model_configuration/solar.yaml
+++ b/src/antares_gems_converter/input_converter/data/model_configuration/solar.yaml
@@ -21,7 +21,7 @@ template:
       # exclude:
 
   components:
-    - id: solar_${area}
+    - id: ${area}_solar
       parameters:
         - id: nominal_capacity
           time-dependent: false
@@ -50,14 +50,14 @@ template:
 
   # For full modeler mode
   connections:
-    - component1: solar_${area}
+    - component1: ${area}_solar
       port1: balance_port
-      component2: ${area}
+      component2: ${area}_node
       port2: balance_port
 
   # For hybrid mode
   area-connections:
-    - component: solar_${area}
+    - component: ${area}_solar
       port: balance_port
       area: ${area}
 

--- a/src/antares_gems_converter/input_converter/data/model_configuration/st-storage.yaml
+++ b/src/antares_gems_converter/input_converter/data/model_configuration/st-storage.yaml
@@ -22,7 +22,7 @@ template:
       # exclude:
 
   components:
-    - id: ${area}_${st_storage}
+    - id: ${area}_short_term_storage_${st_storage}
       parameters:
         - id: reservoir_capacity
           time-dependent: false
@@ -217,14 +217,14 @@ template:
 
   # For full modeler mode
   connections:
-    - component1: ${area}_${st_storage}
+    - component1: ${area}_short_term_storage_${st_storage}
       port1: balance_port
-      component2: ${area}
+      component2: ${area}_node
       port2: balance_port
 
   # For hybrid mode
   area-connections:
-    - component: ${area}_${st_storage}
+    - component: ${area}_short_term_storage_${st_storage}
       port: balance_port
       area: ${area}
 

--- a/src/antares_gems_converter/input_converter/data/model_configuration/thermal.yaml
+++ b/src/antares_gems_converter/input_converter/data/model_configuration/thermal.yaml
@@ -21,7 +21,7 @@ template:
       # exclude:
 
   components:
-    - id: ${area}_${thermal}
+    - id: ${area}_thermal_${thermal}
       parameters:
         - id: cluster_min_gen_modulation
           time-dependent: true
@@ -266,14 +266,14 @@ template:
 
   # For full modeler mode
   connections:
-    - component1: ${area}_${thermal}
+    - component1: ${area}_thermal_${thermal}
       port1: balance_port
-      component2: ${area}
+      component2: ${area}_node
       port2: balance_port
 
   # For hybrid mode
   area-connections:
-    - component: ${area}_${thermal}
+    - component: ${area}_thermal_${thermal}
       port: balance_port
       area: ${area}
 

--- a/src/antares_gems_converter/input_converter/data/model_configuration/thermal.yaml
+++ b/src/antares_gems_converter/input_converter/data/model_configuration/thermal.yaml
@@ -260,9 +260,6 @@ template:
               area: ${area}
               cluster: ${thermal}
               field: group
-        - id: plant
-          value:
-            constant: ${thermal}
 
   # For full modeler mode
   connections:

--- a/src/antares_gems_converter/input_converter/data/model_configuration/wind.yaml
+++ b/src/antares_gems_converter/input_converter/data/model_configuration/wind.yaml
@@ -22,7 +22,7 @@ template:
       # exclude:
 
   components:
-    - id: wind_${area}
+    - id: ${area}_wind
       parameters:
         - id: nominal_capacity
           time-dependent: false
@@ -51,14 +51,14 @@ template:
 
   # For full modeler mode
   connections:
-    - component1: wind_${area}
+    - component1: ${area}_wind
       port1: balance_port
-      component2: ${area}
+      component2: ${area}_node
       port2: balance_port
 
   # For hybrid mode
   area-connections:
-    - component: wind_${area}
+    - component: ${area}_wind
       port: balance_port
       area: ${area}
 

--- a/src/antares_gems_converter/input_converter/src/converter.py
+++ b/src/antares_gems_converter/input_converter/src/converter.py
@@ -259,7 +259,7 @@ class AntaresStudyConverter:
             )
             components.append(
                 ComponentSchema(
-                    id=(comp.id).replace(" ", "_"),
+                    id=(comp.id).replace(" / ", "_"),
                     model=resolved_conversion_template.model,
                     scenario_group=resolved_conversion_template.scenario_group,
                     parameters=parameters,
@@ -279,7 +279,7 @@ class AntaresStudyConverter:
                         )
                     else:
                         component_value = area_connection.component
-                    component_value = component_value.replace(" ", "_")
+                    component_value = component_value.replace(" / ", "_")
                     if "." in area_connection.area:
                         area_parts = area_connection.area.split(".")
                         area_value = getattr(
@@ -287,7 +287,7 @@ class AntaresStudyConverter:
                         )
                     else:
                         area_value = area_connection.area
-                    area_value = area_value.replace(" ", "_")
+                    area_value = area_value.replace(" / ", "_")
                     area_connections.append(
                         AreaConnectionsSchema(
                             component=component_value,
@@ -312,10 +312,10 @@ class AntaresStudyConverter:
                             component_value = getattr(
                                 self.study.get_links()[component_parts[0]],
                                 component_parts[1],
-                            )
+                            ) + ".".join(component_parts[2:])
                         else:
                             component_value = component
-                        treated_components.append(component_value.replace(" ", "_"))
+                        treated_components.append(component_value.replace(" / ", "_"))
 
                     connections.append(
                         PortConnectionsSchema(

--- a/src/antares_gems_converter/libs/antares_historic/antares_legacy_models.yml
+++ b/src/antares_gems_converter/libs/antares_historic/antares_legacy_models.yml
@@ -274,7 +274,6 @@ library:
         - id: objective
           expression: sum(market_bid_cost * generation_power + startup_cost * num_units_starting + fixed_cost * num_units_on)
       properties:
-        - id: plant
         - id: carrier
         - id: technology
       extra-outputs:

--- a/src/antares_gems_converter/taxonomies/antares_legacy_taxonomy.yml
+++ b/src/antares_gems_converter/taxonomies/antares_legacy_taxonomy.yml
@@ -60,7 +60,6 @@ taxonomy:
         - id: profit
       properties:
         - id: technology
-        - id: plant
 
     - id: fatal_generation
       parent-category: generation

--- a/tests/input_converter/resources/mini_test_batterie_BP23/reference.yaml
+++ b/tests/input_converter/resources/mini_test_batterie_BP23/reference.yaml
@@ -1,6 +1,6 @@
 system:
   components:
-    - id: fr
+    - id: fr_node
       model: antares_legacy_models.area
       parameters:
         - id: unsupplied_energy_cost
@@ -14,7 +14,7 @@ system:
       properties:
         - id: carrier
           value: electricity
-    - id: battery_fr
+    - id: fr_battery
       model: andromede-v1-models.battery
       parameters:
         - id: reservoir_capacity
@@ -44,43 +44,43 @@ system:
         - id: upper_rule_curve
           scenario-dependent: false
           time-dependent: true
-          value: upper_rule_curve_battery_fr
+          value: upper_rule_curve_fr_battery
         - id: p_max_injection_modulation
           scenario-dependent: false
           time-dependent: true
-          value: p_max_injection_modulation_battery_fr
+          value: p_max_injection_modulation_fr_battery
         - id: p_max_withdrawal_modulation
           scenario-dependent: false
           time-dependent: true
-          value: p_max_withdrawal_modulation_battery_fr
+          value: p_max_withdrawal_modulation_fr_battery
         - id: marginal_cost
           scenario-dependent: false
           time-dependent: true
-          value: marginal_cost_battery_fr
+          value: marginal_cost_fr_battery
       properties:
         - id: carrier
           value: electricity
-    - id: load_fr
+    - id: fr_load
       model: antares_legacy_models.load
       parameters:
         - id: load
           scenario-dependent: true
           time-dependent: true
-          value: load_load_fr
+          value: load_fr_load
       properties:
         - id: carrier
           value: electricity
-    - id: fr_fr_nuclear_epr
+    - id: fr_thermal_fr_nuclear_epr
       model: antares_legacy_models.thermal
       parameters:
         - id: cluster_min_gen_modulation
           scenario-dependent: true
           time-dependent: true
-          value: cluster_min_gen_modulation_fr_fr_nuclear_epr
+          value: cluster_min_gen_modulation_fr_thermal_fr_nuclear_epr
         - id: cluster_max_generation
           scenario-dependent: true
           time-dependent: true
-          value: cluster_max_generation_fr_fr_nuclear_epr
+          value: cluster_max_generation_fr_thermal_fr_nuclear_epr
         - id: min_power_per_unit
           scenario-dependent: false
           time-dependent: false
@@ -181,16 +181,16 @@ system:
         - id: plant
           value: fr_nuclear_epr
   connections:
-    - component1: battery_fr
-      component2: fr
+    - component1: fr_battery
+      component2: fr_node
       port1: injection_port
       port2: balance_port
-    - component1: load_fr
-      component2: fr
+    - component1: fr_load
+      component2: fr_node
       port1: balance_port
       port2: balance_port
-    - component1: fr_fr_nuclear_epr
-      component2: fr
+    - component1: fr_thermal_fr_nuclear_epr
+      component2: fr_node
       port1: balance_port
       port2: balance_port
   id: mini_test_batterie_BP23

--- a/tests/input_converter/resources/mini_test_batterie_BP23/reference.yaml
+++ b/tests/input_converter/resources/mini_test_batterie_BP23/reference.yaml
@@ -178,8 +178,6 @@ system:
           value: electricity
         - id: technology
           value: nuclear
-        - id: plant
-          value: fr_nuclear_epr
   connections:
     - component1: fr_battery
       component2: fr_node

--- a/tests/input_converter/resources/mini_test_batterie_BP23/reference_hybrid.yaml
+++ b/tests/input_converter/resources/mini_test_batterie_BP23/reference_hybrid.yaml
@@ -1,10 +1,10 @@
 system:
   area-connections:
   - area: fr
-    component: battery_fr
+    component: fr_battery
     port: injection_port
   components:
-  - id: battery_fr
+  - id: fr_battery
     model: andromede-v1-models.battery
     parameters:
     - id: reservoir_capacity
@@ -34,19 +34,19 @@ system:
     - id: upper_rule_curve
       scenario-dependent: false
       time-dependent: true
-      value: upper_rule_curve_battery_fr
+      value: upper_rule_curve_fr_battery
     - id: p_max_injection_modulation
       scenario-dependent: false
       time-dependent: true
-      value: p_max_injection_modulation_battery_fr
+      value: p_max_injection_modulation_fr_battery
     - id: p_max_withdrawal_modulation
       scenario-dependent: false
       time-dependent: true
-      value: p_max_withdrawal_modulation_battery_fr
+      value: p_max_withdrawal_modulation_fr_battery
     - id: marginal_cost
       scenario-dependent: false
       time-dependent: true
-      value: marginal_cost_battery_fr
+      value: marginal_cost_fr_battery
     properties:
     - id: carrier
       value: electricity

--- a/tests/input_converter/test_converter.py
+++ b/tests/input_converter/test_converter.py
@@ -628,7 +628,6 @@ class TestConverter:
                 properties=[
                     ComponentPropertySchema(id="carrier", value="electricity"),
                     ComponentPropertySchema(id="technology", value="other 1"),
-                    ComponentPropertySchema(id="plant", value="gaz"),
                 ],
             )
         ]

--- a/tests/input_converter/test_converter.py
+++ b/tests/input_converter/test_converter.py
@@ -116,7 +116,7 @@ class TestConverter:
             id="studyTest",
             components=[
                 ComponentSchema(
-                    id="fr",
+                    id="fr_node",
                     model="antares_legacy_models.area",
                     scenario_group=None,
                     parameters=[
@@ -140,7 +140,7 @@ class TestConverter:
                     ],
                 ),
                 ComponentSchema(
-                    id="it",
+                    id="it_node",
                     model="antares_legacy_models.area",
                     scenario_group=None,
                     parameters=[
@@ -178,7 +178,7 @@ class TestConverter:
 
         expected_area_components = [
             ComponentSchema(
-                id="fr",
+                id="fr_node",
                 model="antares_legacy_models.area",
                 parameters=[
                     ComponentParameterSchema(
@@ -199,7 +199,7 @@ class TestConverter:
                 properties=[ComponentPropertySchema(id="carrier", value="electricity")],
             ),
             ComponentSchema(
-                id="it",
+                id="it_node",
                 model="antares_legacy_models.area",
                 parameters=[
                     ComponentParameterSchema(
@@ -244,7 +244,7 @@ class TestConverter:
             id="studyTest",
             components=[
                 ComponentSchema(
-                    id="fr",
+                    id="fr_node",
                     model="antares_legacy_models.area",
                     scenario_group=None,
                     parameters=[
@@ -268,7 +268,7 @@ class TestConverter:
                     ],
                 ),
                 ComponentSchema(
-                    id="it",
+                    id="it_node",
                     model="antares_legacy_models.area",
                     scenario_group=None,
                     parameters=[
@@ -314,25 +314,27 @@ class TestConverter:
             _,
         ) = converter._convert_model_to_component_list(resource_content)
 
-        inflows_path = "inflows_fr_storage_1"
-        lower_rule_curve_path = "lower_rule_curve_fr_storage_1"
-        pmax_injection_path = "max_injection_modulation_fr_storage_1"
-        pmax_withdrawal_path = "max_withdrawal_modulation_fr_storage_1"
-        upper_rule_curve_path = "upper_rule_curve_fr_storage_1"
-        cost_injection_path = "injection_cost_fr_storage_1"
-        cost_withdrawal_path = "withdrawal_cost_fr_storage_1"
-        cost_level_path = "level_cost_fr_storage_1"
+        inflows_path = "inflows_fr_short_term_storage_storage_1"
+        lower_rule_curve_path = "lower_rule_curve_fr_short_term_storage_storage_1"
+        pmax_injection_path = "max_injection_modulation_fr_short_term_storage_storage_1"
+        pmax_withdrawal_path = (
+            "max_withdrawal_modulation_fr_short_term_storage_storage_1"
+        )
+        upper_rule_curve_path = "upper_rule_curve_fr_short_term_storage_storage_1"
+        cost_injection_path = "injection_cost_fr_short_term_storage_storage_1"
+        cost_withdrawal_path = "withdrawal_cost_fr_short_term_storage_storage_1"
+        cost_level_path = "level_cost_fr_short_term_storage_storage_1"
         expected_storage_connections = [
             PortConnectionsSchema(
-                component1="fr_storage_1",
+                component1="fr_short_term_storage_storage_1",
                 port1="balance_port",
-                component2="fr",
+                component2="fr_node",
                 port2="balance_port",
             )
         ]
         expected_storage_component = [
             ComponentSchema(
-                id="fr_storage_1",
+                id="fr_short_term_storage_storage_1",
                 model=f"{lib_id}.short_term_storage",
                 scenario_group=None,
                 parameters=[
@@ -450,13 +452,13 @@ class TestConverter:
                         id="injection_variation_penalty",
                         time_dependent=True,
                         scenario_dependent=False,
-                        value=f"injection_variation_penalty_fr_storage_1",
+                        value=f"injection_variation_penalty_fr_short_term_storage_storage_1",
                     ),
                     ComponentParameterSchema(
                         id="withdrawal_variation_penalty",
                         time_dependent=True,
                         scenario_dependent=False,
-                        value=f"withdrawal_variation_penalty_fr_storage_1",
+                        value=f"withdrawal_variation_penalty_fr_short_term_storage_storage_1",
                     ),
                     ComponentParameterSchema(
                         id="overflow_cost",
@@ -502,15 +504,15 @@ class TestConverter:
         print(thermals_components)
         expected_thermals_connections = [
             PortConnectionsSchema(
-                component1="fr_gaz",
+                component1="fr_thermal_gaz",
                 port1="balance_port",
-                component2="fr",
+                component2="fr_node",
                 port2="balance_port",
             )
         ]
         expected_thermals_components = [
             ComponentSchema(
-                id="fr_gaz",
+                id="fr_thermal_gaz",
                 model="antares_legacy_models.thermal",
                 scenario_group=None,
                 parameters=[
@@ -519,14 +521,14 @@ class TestConverter:
                         time_dependent=True,
                         scenario_dependent=True,
                         scenario_group=None,
-                        value="cluster_min_gen_modulation_fr_gaz",
+                        value="cluster_min_gen_modulation_fr_thermal_gaz",
                     ),
                     ComponentParameterSchema(
                         id="cluster_max_generation",
                         time_dependent=True,
                         scenario_dependent=True,
                         scenario_group=None,
-                        value="cluster_max_generation_fr_gaz",
+                        value="cluster_max_generation_fr_thermal_gaz",
                     ),
                     ComponentParameterSchema(
                         id="min_power_per_unit",
@@ -653,21 +655,25 @@ class TestConverter:
         ) = converter._convert_model_to_component_list(resource_content)
 
         hydro_fr_component = next(
-            (comp for comp in hydro_components if comp.id == "lt_storage_fr"), None
+            (comp for comp in hydro_components if comp.id == "fr_hydro_storage"), None
         )
         hydro_fr_connection = next(
-            (conn for conn in hydro_connections if conn.component1 == "lt_storage_fr"),
+            (
+                conn
+                for conn in hydro_connections
+                if conn.component1 == "fr_hydro_storage"
+            ),
             None,
         )
 
         expected_hydro_connection = PortConnectionsSchema(
-            component1="lt_storage_fr",
+            component1="fr_hydro_storage",
             port1="balance_port",
-            component2="fr",
+            component2="fr_node",
             port2="balance_port",
         )
         expected_hydro_component = ComponentSchema(
-            id="lt_storage_fr",
+            id="fr_hydro_storage",
             model="antares_legacy_models.long_term_storage",
             scenario_group=None,
             parameters=[
@@ -683,21 +689,21 @@ class TestConverter:
                     time_dependent=True,
                     scenario_dependent=True,
                     scenario_group=None,
-                    value="nominal_pumping_capacity_lt_storage_fr",
+                    value="nominal_pumping_capacity_fr_hydro_storage",
                 ),
                 ComponentParameterSchema(
                     id="nominal_generation_capacity",
                     time_dependent=True,
                     scenario_dependent=True,
                     scenario_group=None,
-                    value="nominal_generation_capacity_lt_storage_fr",
+                    value="nominal_generation_capacity_fr_hydro_storage",
                 ),
                 ComponentParameterSchema(
                     id="minimum_generation",
                     time_dependent=True,
                     scenario_dependent=True,
                     scenario_group=None,
-                    value="minimum_generation_lt_storage_fr",
+                    value="minimum_generation_fr_hydro_storage",
                 ),
                 ComponentParameterSchema(
                     id="pumping_efficiency",
@@ -711,28 +717,28 @@ class TestConverter:
                     time_dependent=True,
                     scenario_dependent=False,
                     scenario_group=None,
-                    value="lower_rule_curve_lt_storage_fr",
+                    value="lower_rule_curve_fr_hydro_storage",
                 ),
                 ComponentParameterSchema(
                     id="upper_rule_curve",
                     time_dependent=True,
                     scenario_dependent=False,
                     scenario_group=None,
-                    value="upper_rule_curve_lt_storage_fr",
+                    value="upper_rule_curve_fr_hydro_storage",
                 ),
                 ComponentParameterSchema(
                     id="inflows",
                     time_dependent=True,
                     scenario_dependent=True,
                     scenario_group=None,
-                    value="inflows_lt_storage_fr",
+                    value="inflows_fr_hydro_storage",
                 ),
                 ComponentParameterSchema(
                     id="initial_and_final_level",
                     time_dependent=True,
                     scenario_dependent=True,
                     scenario_group=None,
-                    value="initial_and_final_level_lt_storage_fr",
+                    value="initial_and_final_level_fr_hydro_storage",
                 ),
                 ComponentParameterSchema(
                     id="overflow_cost",
@@ -776,10 +782,10 @@ class TestConverter:
         ) = converter._convert_model_to_component_list(resource_content)
 
         assert load_connections == [
-            c for c in expected_data.connections if c.component1 == "load_fr"
+            c for c in expected_data.connections if c.component1 == "fr_load"
         ]
         assert load_components == [
-            c for c in expected_data.components if c.id == "load_fr"
+            c for c in expected_data.components if c.id == "fr_load"
         ]
         # TODO enrich
 
@@ -803,21 +809,21 @@ class TestConverter:
             _,
         ) = converter._convert_model_to_component_list(resource_content)
         solar_fr_component = next(
-            (comp for comp in solar_components if comp.id == "solar_fr"), None
+            (comp for comp in solar_components if comp.id == "fr_solar"), None
         )
         solar_fr_connection = next(
-            (conn for conn in solar_connections if conn.component1 == "solar_fr"), None
+            (conn for conn in solar_connections if conn.component1 == "fr_solar"), None
         )
-        solar_timeseries = "available_power_solar_fr"
+        solar_timeseries = "available_power_fr_solar"
         expected_solar_connection = PortConnectionsSchema(
-            component1="solar_fr",
+            component1="fr_solar",
             port1="balance_port",
-            component2="fr",
+            component2="fr_node",
             port2="balance_port",
         )
 
         expected_solar_components = ComponentSchema(
-            id="solar_fr",
+            id="fr_solar",
             model="antares_legacy_models.renewable",
             scenario_group=None,
             parameters=[
@@ -864,21 +870,21 @@ class TestConverter:
             _,
         ) = converter._convert_model_to_component_list(resource_content)
         load_fr_component = next(
-            (comp for comp in load_components if comp.id == "load_fr"), None
+            (comp for comp in load_components if comp.id == "fr_load"), None
         )
         load_fr_connection = next(
-            (conn for conn in load_connections if conn.component1 == "load_fr"), None
+            (conn for conn in load_connections if conn.component1 == "fr_load"), None
         )
 
-        load_timeseries = "load_load_fr"
+        load_timeseries = "load_fr_load"
         expected_load_connection = PortConnectionsSchema(
-            component1="load_fr",
+            component1="fr_load",
             port1="balance_port",
-            component2="fr",
+            component2="fr_node",
             port2="balance_port",
         )
         expected_load_components = ComponentSchema(
-            id="load_fr",
+            id="fr_load",
             model="antares_legacy_models.load",
             scenario_group=None,
             parameters=[
@@ -914,20 +920,20 @@ class TestConverter:
             _,
         ) = converter._convert_model_to_component_list(resource_content)
         wind_fr_component = next(
-            (comp for comp in wind_components if comp.id == "wind_fr"), None
+            (comp for comp in wind_components if comp.id == "fr_wind"), None
         )
         wind_fr_connection = next(
-            (conn for conn in wind_connections if conn.component1 == "wind_fr"), None
+            (conn for conn in wind_connections if conn.component1 == "fr_wind"), None
         )
 
         expected_wind_connection = PortConnectionsSchema(
-            component1="wind_fr",
+            component1="fr_wind",
             port1="balance_port",
-            component2="fr",
+            component2="fr_node",
             port2="balance_port",
         )
         expected_wind_components = ComponentSchema(
-            id="wind_fr",
+            id="fr_wind",
             model="antares_legacy_models.renewable",
             scenario_group="wind_group",
             parameters=[
@@ -947,7 +953,7 @@ class TestConverter:
                     id="available_power",
                     time_dependent=True,
                     scenario_dependent=True,
-                    value="available_power_wind_fr",
+                    value="available_power_fr_wind",
                 ),
             ],
             properties=[
@@ -1026,32 +1032,32 @@ class TestConverter:
 
         expected_misc_gen_connections = [
             PortConnectionsSchema(
-                component1=f"{generation_type}_fr",
+                component1=f"fr_{generation_type}",
                 port1="balance_port",
-                component2="fr",
+                component2="fr_node",
                 port2="balance_port",
             )
             for generation_type in [
-                "chp",
+                "combined_heat_power",
                 "biomass",
                 "biogas",
                 "waste",
                 "geothermal",
                 "other",
-                "psp",
-                "rest_of_world",
+                "pumped_storage_power",
+                "rest_world",
             ]
         ]
         expected_misc_gen_components = [
             ComponentSchema(
-                id=f"{generation_type}_fr",
+                id=f"fr_{generation_type}",
                 model="antares_legacy_models.miscellaneous_generation",
                 parameters=[
                     ComponentParameterSchema(
                         id="available_power",
                         time_dependent=True,
                         scenario_dependent=False,
-                        value=f"available_power_{generation_type}_fr",
+                        value=f"available_power_fr_{generation_type}",
                     )
                 ],
                 properties=[
@@ -1060,20 +1066,20 @@ class TestConverter:
                     ComponentPropertySchema(
                         id="miscellaneous_type",
                         value="misc_ndg"
-                        if generation_type not in ["psp", "rest_of_world"]
+                        if generation_type not in ["pumped_storage_power", "rest_world"]
                         else generation_type,
                     ),
                 ],
             )
             for generation_type in [
-                "chp",
+                "combined_heat_power",
                 "biomass",
                 "biogas",
                 "waste",
                 "geothermal",
                 "other",
-                "psp",
-                "rest_of_world",
+                "pumped_storage_power",
+                "rest_world",
             ]
         ]
         assert misc_gen_connections == expected_misc_gen_connections
@@ -1126,22 +1132,22 @@ class TestConverter:
 
         expected_misc_gen_connections = [
             PortConnectionsSchema(
-                component1=f"biomass_fr",
+                component1=f"fr_biomass",
                 port1="balance_port",
-                component2="fr",
+                component2="fr_node",
                 port2="balance_port",
             )
         ]
         expected_misc_gen_components = [
             ComponentSchema(
-                id=f"biomass_fr",
+                id=f"fr_biomass",
                 model="antares_legacy_models.miscellaneous_generation",
                 parameters=[
                     ComponentParameterSchema(
                         id="available_power",
                         time_dependent=True,
                         scenario_dependent=False,
-                        value=f"available_power_biomass_fr",
+                        value=f"available_power_fr_biomass",
                     )
                 ],
                 properties=[
@@ -1173,20 +1179,21 @@ class TestConverter:
             _,
         ) = converter._convert_model_to_component_list(resource_content)
         ror_fr_component = next(
-            (comp for comp in ror_components if comp.id == "ror_fr"), None
+            (comp for comp in ror_components if comp.id == "fr_run_of_river"), None
         )
         ror_fr_connection = next(
-            (conn for conn in ror_connections if conn.component1 == "ror_fr"), None
+            (conn for conn in ror_connections if conn.component1 == "fr_run_of_river"),
+            None,
         )
 
         expected_ror_connection = PortConnectionsSchema(
-            component1="ror_fr",
+            component1="fr_run_of_river",
             port1="balance_port",
-            component2="fr",
+            component2="fr_node",
             port2="balance_port",
         )
         expected_ror_component = ComponentSchema(
-            id="ror_fr",
+            id="fr_run_of_river",
             model="antares_legacy_models.renewable",
             scenario_group=None,
             parameters=[
@@ -1206,7 +1213,7 @@ class TestConverter:
                     id="available_power",
                     time_dependent=True,
                     scenario_dependent=True,
-                    value="available_power_ror_fr",
+                    value="available_power_fr_run_of_river",
                 ),
             ],
             properties=[
@@ -1275,24 +1282,24 @@ class TestConverter:
             _,
         ) = converter._convert_model_to_component_list(resource_content)
 
-        fr_it_direct_links_timeseries = "direct_capacity_fr_it"
-        fr_it_indirect_links_timeseries = "indirect_capacity_fr_it"
-        fr_it_direct_costs_timeseries = "direct_hurdle_cost_fr_it"
-        fr_it_indirect_costs_timeseries = "indirect_hurdle_cost_fr_it"
-        at_fr_direct_links_timeseries = "direct_capacity_at_fr"
-        at_fr_indirect_links_timeseries = "indirect_capacity_at_fr"
-        at_it_direct_links_timeseries = "direct_capacity_at_it"
-        at_it_indirect_links_timeseries = "indirect_capacity_at_it"
-        at_fr_direct_costs_timeseries = "direct_hurdle_cost_at_fr"
-        at_fr_indirect_costs_timeseries = "indirect_hurdle_cost_at_fr"
-        at_it_direct_costs_timeseries = "direct_hurdle_cost_at_it"
-        at_it_indirect_costs_timeseries = "indirect_hurdle_cost_at_it"
-        fr_it_loop_flow_timeseries = "loop_flow_fr_it"
-        at_fr_loop_flow_timeseries = "loop_flow_at_fr"
-        at_it_loop_flow_timeseries = "loop_flow_at_it"
+        fr_it_direct_links_timeseries = "direct_capacity_fr_it_link"
+        fr_it_indirect_links_timeseries = "indirect_capacity_fr_it_link"
+        fr_it_direct_costs_timeseries = "direct_hurdle_cost_fr_it_link"
+        fr_it_indirect_costs_timeseries = "indirect_hurdle_cost_fr_it_link"
+        at_fr_direct_links_timeseries = "direct_capacity_at_fr_link"
+        at_fr_indirect_links_timeseries = "indirect_capacity_at_fr_link"
+        at_it_direct_links_timeseries = "direct_capacity_at_it_link"
+        at_it_indirect_links_timeseries = "indirect_capacity_at_it_link"
+        at_fr_direct_costs_timeseries = "direct_hurdle_cost_at_fr_link"
+        at_fr_indirect_costs_timeseries = "indirect_hurdle_cost_at_fr_link"
+        at_it_direct_costs_timeseries = "direct_hurdle_cost_at_it_link"
+        at_it_indirect_costs_timeseries = "indirect_hurdle_cost_at_it_link"
+        fr_it_loop_flow_timeseries = "loop_flow_fr_it_link"
+        at_fr_loop_flow_timeseries = "loop_flow_at_fr_link"
+        at_it_loop_flow_timeseries = "loop_flow_at_it_link"
         expected_link_component = [
             ComponentSchema(
-                id="fr_/_it",
+                id="fr_it_link",
                 model="antares_legacy_models.link",
                 scenario_group=None,
                 parameters=[
@@ -1337,7 +1344,7 @@ class TestConverter:
                 ],
             ),
             ComponentSchema(
-                id="at_/_fr",
+                id="at_fr_link",
                 model="antares_legacy_models.link",
                 scenario_group=None,
                 parameters=[
@@ -1382,7 +1389,7 @@ class TestConverter:
                 ],
             ),
             ComponentSchema(
-                id="at_/_it",
+                id="at_it_link",
                 model="antares_legacy_models.link",
                 scenario_group=None,
                 parameters=[
@@ -1430,39 +1437,39 @@ class TestConverter:
 
         expected_link_connections = [
             PortConnectionsSchema(
-                component1="at_/_fr",
+                component1="at_fr_link",
                 port1="in_port",
-                component2="at",
+                component2="at_node",
                 port2="balance_port",
             ),
             PortConnectionsSchema(
-                component1="at_/_fr",
+                component1="at_fr_link",
                 port1="out_port",
-                component2="fr",
+                component2="fr_node",
                 port2="balance_port",
             ),
             PortConnectionsSchema(
-                component1="at_/_it",
+                component1="at_it_link",
                 port1="in_port",
-                component2="at",
+                component2="at_node",
                 port2="balance_port",
             ),
             PortConnectionsSchema(
-                component1="at_/_it",
+                component1="at_it_link",
                 port1="out_port",
-                component2="it",
+                component2="it_node",
                 port2="balance_port",
             ),
             PortConnectionsSchema(
-                component1="fr_/_it",
+                component1="fr_it_link",
                 port1="in_port",
-                component2="fr",
+                component2="fr_node",
                 port2="balance_port",
             ),
             PortConnectionsSchema(
-                component1="fr_/_it",
+                component1="fr_it_link",
                 port1="out_port",
-                component2="it",
+                component2="it_node",
                 port2="balance_port",
             ),
         ]
@@ -1519,10 +1526,10 @@ class TestConverter:
 
         assert area_connections == []
         assert binding_connections == [
-            c for c in expected_data.connections if c.component1 == "battery_fr"
+            c for c in expected_data.connections if c.component1 == "fr_battery"
         ]
         assert binding_components == [
-            c for c in expected_data.components if c.id == "battery_fr"
+            c for c in expected_data.components if c.id == "fr_battery"
         ]
         # TODO enrich
 
@@ -1558,21 +1565,21 @@ class TestConverter:
         ) = converter._convert_model_to_component_list(bc_data)
 
         output_path = converter.output_folder
-        path1 = output_path / "input" / "data-series" / "marginal_cost_battery_fr.tsv"
+        path1 = output_path / "input" / "data-series" / "marginal_cost_fr_battery.tsv"
         path2 = (
             output_path
             / "input"
             / "data-series"
-            / "p_max_injection_modulation_battery_fr.tsv"
+            / "p_max_injection_modulation_fr_battery.tsv"
         )
         path3 = (
             output_path
             / "input"
             / "data-series"
-            / "p_max_withdrawal_modulation_battery_fr.tsv"
+            / "p_max_withdrawal_modulation_fr_battery.tsv"
         )
         path4 = (
-            output_path / "input" / "data-series" / "upper_rule_curve_battery_fr.tsv"
+            output_path / "input" / "data-series" / "upper_rule_curve_fr_battery.tsv"
         )
         assert check_file_exists(path1)
         assert check_file_exists(path2)
@@ -1581,7 +1588,7 @@ class TestConverter:
         ### Compare area connections
         expected_area_connections = [
             AreaConnectionsSchema(
-                component="battery_fr", port="injection_port", area="fr"
+                component="fr_battery", port="injection_port", area="fr"
             )
         ]
         assert area_connections == expected_area_connections


### PR DESCRIPTION
## Process ID

**Process:** A2G-02

## Description

Standardise component IDs across all model configuration templates to use a consistent ${variable}_<type> naming convention (e.g. ${area}_node, ${area}_battery, ${link}_link), replacing the previous mixed patterns (battery_${area}, lt_storage_${area}, bare ${area}, etc.).

Connection references in templates, converter.py, and tests have been updated accordingly.

Remove the plant property from the thermal model, catalog entries, taxonomy, and configuration template — it was redundant with the existing cluster identifier and is not needed.

## Impact Analysis

- All templates under input_converter/data/model_configuration/ are affected by the ID renaming.
- The plant property is removed from the thermal model (antares_legacy_models.yml), thermal catalog (antares_legacy_thermal_cluster_catalog.yml), taxonomy (antares_legacy_taxonomy.yml), and thermal configuration template (thermal.yaml).
- Breaking change: component IDs in generated GEMS studies change for any study produced with a previous version of the converter.
- No change to converter logic, parameters, or port definitions.

## Checklist

- [x] Solver equivalence tests pass (`pytest tests/antares_historic/`)
- [x] `pyproject.toml` version bumped if converter logic changed
- [x] Changelog entry added if library changed (`CHANGELOG-antares_legacy_models_library.md`)
- [x] `COMPATIBILITY.md` updated if supported versions changed
- [x] Documentation updated or confirmed up to date
- [x] `AGENTS.md` reviewed for impact and updated if needed
