### PR TITLE
update lold and lolp computation

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -4,7 +4,7 @@ This table maps converter versions to the tool versions they are compatible with
 
 | Converter | Antares-Simulator | antares-craft | GemsPy | Notes |
 |-----------|-------------------|---------------|--------|-------|
-| 0.2.0     | 10.1.0            | 0.14.0        | 0.1.2  | GemsPy 0.1.2; Antares Legacy Models Library 2.1.1; all component properties now converted via templates (only `electricity` carrier supported)|
+| 0.2.0     | 10.1.0            | 0.14.0        | 0.1.2  | GemsPy 0.1.2; Antares Legacy Models Library 2.1.2; all component properties now converted via templates (only `electricity` carrier supported)|
 | 0.1.3     | 10.1.0            | 0.14.0        | 0.1.0  | Antares Legacy Models Library 2.1.0: market bid cost in thermal, STS overflow and variation penalties |
 | 0.1.2     | 10.1.0            | 0.14.0        | 0.1.0  | New templates for hydro and misc gen, changes on template parsing |
 | 0.1.1     | 10.1.0            | 0.14.0        | 0.1.0  | Added new models in Antares Legacy Models |
@@ -59,7 +59,7 @@ Runtime and development Python packages are pinned to exact versions in `pyproje
 | Component | Current Version | Version File |
 |-----------|----------------|--------------|
 | Converter | 0.2.0 | `pyproject.toml` |
-| Antares Legacy Models Library | 2.1.1 | `src/antares_gems_converter/libs/antares_historic/antares_legacy_models.yml` |
+| Antares Legacy Models Library | 2.1.2 | `src/antares_gems_converter/libs/antares_historic/antares_legacy_models.yml` |
 | Antares-Simulator | 10.1.0 | `dependencies.json` |
 | antares-craft | 0.14.0 | `pyproject.toml` |
 | GemsPy | 0.1.2 | `pyproject.toml` |

--- a/src/antares_gems_converter/catalogs/antares_legacy_area_catalog.yml
+++ b/src/antares_gems_converter/catalogs/antares_legacy_area_catalog.yml
@@ -289,7 +289,7 @@ catalog:
   - id: LOLP
     terms:
       - taxonomy-category: balance
-        output-id: is_loss_of_load
+        output-id: is_significant_loss_of_load
         location-ports: null
     terms-operator: avg
     time-operator: avg

--- a/src/antares_gems_converter/catalogs/antares_legacy_area_catalog.yml
+++ b/src/antares_gems_converter/catalogs/antares_legacy_area_catalog.yml
@@ -281,7 +281,7 @@ catalog:
   - id: LOLD
     terms:
       - taxonomy-category: balance
-        output-id: is_loss_of_load
+        output-id: is_significant_loss_of_load
         location-ports: null
     terms-operator: sum
     time-operator: sum
@@ -289,7 +289,7 @@ catalog:
   - id: LOLP
     terms:
       - taxonomy-category: balance
-        output-id: is_significant_loss_of_load
+        output-id: is_loss_of_load
         location-ports: null
     terms-operator: avg
     time-operator: avg

--- a/src/antares_gems_converter/libs/antares_historic/CHANGELOG-antares_legacy_models_library.md
+++ b/src/antares_gems_converter/libs/antares_historic/CHANGELOG-antares_legacy_models_library.md
@@ -10,6 +10,12 @@ Versioning follows the rules defined in `COMPATIBILITY.md`:
 
 ---
 
+## [2.1.2]
+
+- `area` model: added `is_significant_loss_of_load` extra-output (`unsupplied_energy >= 0.5`); `is_loss_of_load` now captures any non-zero unsupplied energy (`unsupplied_energy >= 1e-6`).
+
+---
+
 ## [2.1.1]
 
 - Added `carrier` property to `link`, `short_term_storage`, and `long_term_storage` models.

--- a/src/antares_gems_converter/libs/antares_historic/antares_legacy_models.yml
+++ b/src/antares_gems_converter/libs/antares_historic/antares_legacy_models.yml
@@ -12,7 +12,7 @@
 library:
   id: antares_legacy_models
   description: Antares historic model library
-  version: "2.1.1"
+  version: "2.1.2"
   taxonomy: antares_legacy_taxonomy
 
   port-types:
@@ -58,6 +58,8 @@ library:
         - id: imbalance_cost
           expression: spillage_cost * spilled_energy + unsupplied_energy_cost * unsupplied_energy
         - id: is_loss_of_load
+          expression: unsupplied_energy >= 0.000001
+        - id: is_significant_loss_of_load
           expression: unsupplied_energy >= 0.5
         - id: is_near_loss_of_load
           expression: dual(balance) >= unsupplied_energy_cost - 5

--- a/src/antares_gems_converter/taxonomies/antares_legacy_taxonomy.yml
+++ b/src/antares_gems_converter/taxonomies/antares_legacy_taxonomy.yml
@@ -27,6 +27,7 @@ taxonomy:
         - id: price
         - id: imbalance_cost
         - id: is_loss_of_load
+        - id: is_significant_loss_of_load
         - id: is_near_loss_of_load
 
     - id: generation


### PR DESCRIPTION
## Process ID

**Process:** A2G-02

## Description

Add `is_significant_loss_of_load` (`unsupplied_energy >= 0.5`) to the area model and update `is_loss_of_load` to detect any non-zero unsupplied energy (`>= 1e-6`). LOLD/LOLP catalog metrics updated accordingly. Library bumped to 2.1.2.

## Impact Analysis

- `area` model, `antares_legacy_area_catalog.yml`, `antares_legacy_taxonomy.yml`.
- Breaking change: `is_loss_of_load` semantics changed — use `is_significant_loss_of_load` to preserve the previous behaviour.

## Checklist

- [x] Solver equivalence tests pass (`pytest tests/antares_historic/`)
- [x] `pyproject.toml` version bumped if converter logic changed
- [x] Changelog entry added if library changed (`CHANGELOG-antares_legacy_models_library.md`)
- [x] `COMPATIBILITY.md` updated if supported versions changed
- [x] Documentation updated or confirmed up to date
- [x] `AGENTS.md` reviewed for impact and updated if needed
