### PR TITLE
chore(release): bump version to 0.2.1 and update compatibility notes

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -4,6 +4,7 @@ This table maps converter versions to the tool versions they are compatible with
 
 | Converter | Antares-Simulator | antares-craft | GemsPy | Notes |
 |-----------|-------------------|---------------|--------|-------|
+| 0.2.1     | 10.1.0            | 0.14.0        | 0.1.2  | Packaging fix: include missing YAML files (model libraries) in the pip package |
 | 0.2.0     | 10.1.0            | 0.14.0        | 0.1.2  | GemsPy 0.1.2; Antares Legacy Models Library 2.1.2; all component properties now converted via templates (only `electricity` carrier supported)|
 | 0.1.3     | 10.1.0            | 0.14.0        | 0.1.0  | Antares Legacy Models Library 2.1.0: market bid cost in thermal, STS overflow and variation penalties |
 | 0.1.2     | 10.1.0            | 0.14.0        | 0.1.0  | New templates for hydro and misc gen, changes on template parsing |
@@ -58,7 +59,7 @@ Runtime and development Python packages are pinned to exact versions in `pyproje
 
 | Component | Current Version | Version File |
 |-----------|----------------|--------------|
-| Converter | 0.2.0 | `pyproject.toml` |
+| Converter | 0.2.1 | `pyproject.toml` |
 | Antares Legacy Models Library | 2.1.2 | `src/antares_gems_converter/libs/antares_historic/antares_legacy_models.yml` |
 | Antares-Simulator | 10.1.0 | `dependencies.json` |
 | antares-craft | 0.14.0 | `pyproject.toml` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antares-legacy-gems-converter"
-version = "0.2.0"
+version = "0.2.1"
 description = "Convert Antares Legacy studies to GEMS format"
 readme = "README.md"
 license = "MPL-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -38,7 +38,7 @@ wheels = [
 
 [[package]]
 name = "antares-legacy-gems-converter"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "antares-craft" },


### PR DESCRIPTION
## Process ID

<!-- Which governance process does this PR fall under? -->
<!-- A2G-01 | A2G-02 | A2G-03 | A2G-04 | N/A -->

**Process:**
Bump version/update: 

- `pyproject.toml` 
- `compatbility.md`
- `uv.lock`

## Description

<!-- What does this PR change and why? -->
Release of library new version.
## Impact Analysis

<!-- Which converter modules, models, or studies are affected? -->
<!-- Are there breaking changes to existing study generation? -->

## Checklist

- [ ] Solver equivalence tests pass (`pytest tests/antares_historic/`)
- [ ] `pyproject.toml` version bumped if converter logic changed
- [ ] Changelog entry added if library changed (`CHANGELOG-antares_legacy_models_library.md`)
- [ ] `COMPATIBILITY.md` updated if supported versions changed
- [ ] Documentation updated or confirmed up to date
- [ ] `AGENTS.md` reviewed for impact and updated if needed
