### PR TITLE
chore(deps): bump antares-craft to 0.15.1

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -4,6 +4,7 @@ This table maps converter versions to the tool versions they are compatible with
 
 | Converter | Antares-Simulator | antares-craft | GemsPy | Notes |
 |-----------|-------------------|---------------|--------|-------|
+| 0.3.0     | 10.1.0            | 0.15.1        | 0.1.2  | antares-craft 0.15.1 (bug fix: districts issue in area deletion; unused read_outputs_api/local methods added) |
 | 0.2.1     | 10.1.0            | 0.14.0        | 0.1.2  | Packaging fix: include missing YAML files (model libraries) in the pip package |
 | 0.2.0     | 10.1.0            | 0.14.0        | 0.1.2  | GemsPy 0.1.2; Antares Legacy Models Library 2.1.2; all component properties now converted via templates (only `electricity` carrier supported)|
 | 0.1.3     | 10.1.0            | 0.14.0        | 0.1.0  | Antares Legacy Models Library 2.1.0: market bid cost in thermal, STS overflow and variation penalties |
@@ -36,7 +37,7 @@ Runtime and development Python packages are pinned to exact versions in `pyproje
 
 | Package | Pinned version |
 |---------|----------------|
-| antares-craft | 0.14.0 |
+| antares-craft | 0.15.1 |
 | antares-study-version | 1.0.20 |
 | antares-timeseries-generation | 0.1.9 |
 | gemspy | 0.1.2 |
@@ -59,8 +60,8 @@ Runtime and development Python packages are pinned to exact versions in `pyproje
 
 | Component | Current Version | Version File |
 |-----------|----------------|--------------|
-| Converter | 0.2.1 | `pyproject.toml` |
+| Converter | 0.3.0 | `pyproject.toml` |
 | Antares Legacy Models Library | 2.1.2 | `src/antares_gems_converter/libs/antares_historic/antares_legacy_models.yml` |
 | Antares-Simulator | 10.1.0 | `dependencies.json` |
-| antares-craft | 0.14.0 | `pyproject.toml` |
+| antares-craft | 0.15.1 | `pyproject.toml` |
 | GemsPy | 0.1.2 | `pyproject.toml` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antares-legacy-gems-converter"
-version = "0.2.1"
+version = "0.3.0"
 description = "Convert Antares Legacy studies to GEMS format"
 readme = "README.md"
 license = "MPL-2.0"
@@ -27,7 +27,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "antares_craft==0.14.0",
+    "antares_craft==0.15.1",
     "antares-study-version==1.0.20",
     "antares-timeseries-generation==0.1.9",
     "numpy>=2.2.6",

--- a/uv.lock
+++ b/uv.lock
@@ -18,7 +18,7 @@ wheels = [
 
 [[package]]
 name = "antares-craft"
-version = "0.14.0"
+version = "0.15.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "antares-study-version" },
@@ -31,14 +31,14 @@ dependencies = [
     { name = "pydantic" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1a/68/31422ddfa8e017c6ece6507768ecde08d52aebbd8c587f0eb336144ab9cd/antares_craft-0.14.0.tar.gz", hash = "sha256:ec96d476d217c61475440aa7331a7ea7161b2ef66e84d77e36a393c342f51d08", size = 167170, upload-time = "2026-05-20T08:52:48.538Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/22/c4b801b8a0d87a0092ac582d315b03c20c41e8cbcdd5dad7b5683880b90a/antares_craft-0.15.1.tar.gz", hash = "sha256:0e4422ec0d83027375b02dc43ff4f881c3e3ac012949a1c5bf51e7227b94d28c", size = 169034, upload-time = "2026-07-10T15:42:20.493Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/4c/0cca779057c7d3fa0a350535ef3a71eb8bbfe88a2e97197986dd0e99e52f/antares_craft-0.14.0-py3-none-any.whl", hash = "sha256:3f2f761a01389a35111568bd68e17b0dcd66f6f0f0886f6e500a8b305dcbbae0", size = 243687, upload-time = "2026-05-20T08:52:47.415Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/99/05c8e96951e814b74d2425fa1aeefdab458379bd2bf0ec82ca47de7c529e/antares_craft-0.15.1-py3-none-any.whl", hash = "sha256:be3ed9708513f0ba75e61a1599d18f29e5500c9bd5d58f17c32e148b44b1ce1c", size = 245031, upload-time = "2026-07-10T15:42:19.378Z" },
 ]
 
 [[package]]
 name = "antares-legacy-gems-converter"
-version = "0.2.1"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "antares-craft" },
@@ -62,7 +62,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "antares-craft", specifier = "==0.14.0" },
+    { name = "antares-craft", specifier = "==0.15.1" },
     { name = "antares-study-version", specifier = "==1.0.20" },
     { name = "antares-timeseries-generation", specifier = "==0.1.9" },
     { name = "gemspy", specifier = "==0.1.2" },


### PR DESCRIPTION
## Process ID

**Process:** N/A — routine dependency bump, no converter logic changed.

## Description

Closes #79 (and covers the intervening #70, which flagged 0.15.0).

Bumps the pinned `antares_craft` dependency from `0.14.0` to `0.15.1` in
`pyproject.toml` and regenerates `uv.lock`. No converter source code changes
are included.

**Changelog review (0.14.0 → 0.15.1):**
- **v0.15.0** — new `read_outputs_api`/`read_outputs_local` methods (not used
  by this converter, which never reads simulation outputs); bug fixes for
  duplicate-object checks in local mode and `create_xpansion_configuration`
  (xpansion is not used by this converter either).
- **v0.15.1** — bug fix: "Fixed a districts issue within the area deletion
  method" (`delete_area`), which this converter uses in HYBRID mode
  (`STUDY_LEVEL_DELETION["area"]` in `config.py`, invoked from
  `converter.py` when processing `legacy-objects-to-delete`, e.g. removing
  virtual `z_batteries` areas after battery conversion).

No renamed/removed/breaking API signatures were found affecting any of the
methods this converter calls (`STUDY_LEVEL_GET/DELETION`,
`TEMPLATE_CLUSTER_TYPE_TO_GET/DELETE_METHOD`, `MATRIX_TYPES_TO_GET/SET_METHOD`,
`HYDRO_TYPE_TO_SET_METHOD`, `TIMESERIES_NAME_TO_METHOD`). The only breaking
change in this version range (`update_pmax_injection` → `set_pmax_injection`)
happened in 0.14.0, our prior baseline, and is already reflected in the code.

## Impact Analysis

No converter modules, models, or study generation logic are affected — this
is a dependency-pin-only change. The `delete_area` bug fix in 0.15.1 is a
strict correctness improvement for HYBRID-mode legacy object deletion, not a
behavior change our code depends on differently.

## Checklist

- [x] Solver equivalence tests pass (`pytest tests/antares_historic/`) — the
      `check-antares-craft-update` workflow already ran the full test suite
      against antares-craft 0.15.1 on issue #79 and reported success
      ([run](https://github.com/AntaresSimulatorTeam/AntaresLegacyModels-to-GEMS-Converter/actions/runs/29236078060)).
      `tests/input_converter/` (29 tests) also verified locally against
      0.15.1.
- [x] `pyproject.toml` version bumped (`0.2.1` → `0.3.0`, Minor bump per the
      antares-craft update policy in `COMPATIBILITY.md`)
- [ ] Changelog entry added if library changed — N/A, no model library changes
- [x] `COMPATIBILITY.md` updated (compatibility matrix row, pinned version
      table, version files table)
- [x] Documentation updated or confirmed up to date
- [x] `AGENTS.md` reviewed for impact — no updates needed, no config/mapping
      or template changes

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCmaWXAqrBhBtY5BFGqwGC)_