### PR TITLE
(PR9) Add renewable cluster conversion support [A2G-02]

### DIFF
--- a/src/antares_gems_converter/input_converter/data/model_configuration/renewable.yaml
+++ b/src/antares_gems_converter/input_converter/data/model_configuration/renewable.yaml
@@ -1,0 +1,83 @@
+#
+# See AUTHORS.txt
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# SPDX-License-Identifier: MPL-2.0
+#
+# This file is part of the Antares project.
+
+# Configuration file to convert a complex modelling artefact in an Antares study into an Andromede model.
+
+template:
+  name: renewable
+  generator-version-compatibility: X.Y #TODO: find this information
+  model: antares_legacy_models.renewable
+  template-parameters:
+    - name: area
+      cluster-type: renewable
+      # exclude:
+
+  components:
+    - id: ${area}_renewable_${renewable}
+      parameters:
+        - id: nominal_capacity
+          time-dependent: false
+          scenario-dependent: false
+          value:
+            object-properties:
+              type: renewable
+              area: ${area}
+              cluster: ${renewable}
+              field: nominal_capacity
+        - id: num_units
+          time-dependent: false
+          scenario-dependent: false
+          value:
+            object-properties:
+              type: renewable
+              area: ${area}
+              cluster: ${renewable}
+              field: unit_count
+        - id: available_power
+          time-dependent: true
+          scenario-dependent: true
+          value:
+            object-properties:
+              type: renewable
+              area: ${area}
+              cluster: ${renewable}
+              field: renewable_series
+      properties:
+        - id: carrier
+          value:
+            constant: electricity
+        - id: technology
+          value:
+            object-properties:
+              type: renewable
+              area: ${area}
+              cluster: ${renewable}
+              field: group
+
+  # For full modeler mode
+  connections:
+    - component1: ${area}_renewable_${renewable}
+      port1: balance_port
+      component2: ${area}_node
+      port2: balance_port
+
+  # For hybrid mode
+  area-connections:
+    - component: ${area}_renewable_${renewable}
+      port: balance_port
+      area: ${area}
+
+  legacy-objects-to-delete:
+    - id: legacy_renewable_cluster
+      object-properties:
+        type: renewable
+        area: ${area}
+        cluster: ${renewable}

--- a/src/antares_gems_converter/input_converter/src/config.py
+++ b/src/antares_gems_converter/input_converter/src/config.py
@@ -111,6 +111,7 @@ MODEL_NAME_TO_FILE_NAME = {
     "solar": "solar.yaml",
     "short-term-storage": "st-storage.yaml",
     "thermal": "thermal.yaml",
+    "renewable": "renewable.yaml",
     "wind": "wind.yaml",
     "misc_gen": "misc_gen.yaml",
     "hydro": "hydro.yaml",

--- a/src/antares_gems_converter/input_converter/src/converter.py
+++ b/src/antares_gems_converter/input_converter/src/converter.py
@@ -374,10 +374,20 @@ class AntaresStudyConverter:
                             None,
                         )
                         if cluster_type:
-                            for cluster_id in getattr(
+                            clusters = getattr(
                                 area, TEMPLATE_CLUSTER_TYPE_TO_GET_METHOD[cluster_type]
-                            )():
+                            )()
+                            for cluster_id, cluster in clusters.items():
                                 if cluster_id not in resolved_virtual_objects.thermals:
+                                    if (
+                                        cluster_type == "renewable"
+                                        and not cluster.properties.enabled
+                                    ):
+                                        self.logger.warning(
+                                            f"Renewable cluster '{cluster_id}' in area "
+                                            f"'{area.id}' is disabled; skipping conversion."
+                                        )
+                                        continue
                                     # We have already resolved areas, now need to resolve cluster ids
                                     cluster_resolved_template = (
                                         area_resolved_template.resolve_template(

--- a/src/antares_gems_converter/input_converter/src/data_preprocessing/preprocessing.py
+++ b/src/antares_gems_converter/input_converter/src/data_preprocessing/preprocessing.py
@@ -61,6 +61,25 @@ class ModelConversionPreprocessor:
         link: Link = self.study.get_links()[link_id]
         return getattr(link, TIMESERIES_NAME_TO_METHOD[obj.object_properties.field])()
 
+    def _apply_renewable_ts_interpretation(
+        self, type_resource: str, field: str, cluster: Any, time_series: pd.DataFrame
+    ) -> pd.DataFrame:
+        # Antares "production-factor" series are in [0, 1] (fraction of installed
+        # capacity); the GEMS renewable model expects available_power in MW, so
+        # scale by the cluster's installed capacity.
+        if (
+            type_resource != "renewable"
+            or field != "renewable_series"
+            or cluster.properties.ts_interpretation
+            != TimeSeriesInterpretation.PRODUCTION_FACTOR
+        ):
+            return time_series
+        return (
+            time_series
+            * cluster.properties.nominal_capacity
+            * cluster.properties.unit_count
+        )
+
     def calculate_cluster_data_values(
         self, type_resource: str, obj: ConversionValue
     ) -> Union[Any, pd.DataFrame]:
@@ -83,20 +102,9 @@ class ModelConversionPreprocessor:
             time_series = getattr(
                 cluster, TIMESERIES_NAME_TO_METHOD[obj.object_properties.field]
             )()
-            if (
-                type_resource == "renewable"
-                and obj.object_properties.field == "renewable_series"
-                and cluster.properties.ts_interpretation
-                == TimeSeriesInterpretation.PRODUCTION_FACTOR
-            ):
-                # Antares "production-factor" series are in [0, 1] (fraction of
-                # installed capacity); the GEMS renewable model expects available_power
-                # in MW, so scale by the cluster's installed capacity.
-                time_series = (
-                    time_series
-                    * cluster.properties.nominal_capacity
-                    * cluster.properties.unit_count
-                )
+            time_series = self._apply_renewable_ts_interpretation(
+                type_resource, obj.object_properties.field, cluster, time_series
+            )
         else:
             cluster_properties = getattr(cluster, "properties")
             field_name = obj.object_properties.field

--- a/src/antares_gems_converter/input_converter/src/data_preprocessing/preprocessing.py
+++ b/src/antares_gems_converter/input_converter/src/data_preprocessing/preprocessing.py
@@ -4,6 +4,7 @@ from typing import Any, Union
 import pandas as pd
 from antares.craft.model.binding_constraint import BindingConstraint, ConstraintTerm
 from antares.craft.model.link import Link
+from antares.craft.model.renewable import TimeSeriesInterpretation
 from antares.craft.model.study import Study
 
 from antares_gems_converter.input_converter.src.config import (
@@ -82,6 +83,20 @@ class ModelConversionPreprocessor:
             time_series = getattr(
                 cluster, TIMESERIES_NAME_TO_METHOD[obj.object_properties.field]
             )()
+            if (
+                type_resource == "renewable"
+                and obj.object_properties.field == "renewable_series"
+                and cluster.properties.ts_interpretation
+                == TimeSeriesInterpretation.PRODUCTION_FACTOR
+            ):
+                # Antares "production-factor" series are in [0, 1] (fraction of
+                # installed capacity); the GEMS renewable model expects available_power
+                # in MW, so scale by the cluster's installed capacity.
+                time_series = (
+                    time_series
+                    * cluster.properties.nominal_capacity
+                    * cluster.properties.unit_count
+                )
         else:
             cluster_properties = getattr(cluster, "properties")
             field_name = obj.object_properties.field

--- a/src/antares_gems_converter/input_converter/src/parsing.py
+++ b/src/antares_gems_converter/input_converter/src/parsing.py
@@ -135,6 +135,7 @@ ALLOWED_TYPES: list = [
     "area",
     "binding_constraint",
     "thermal",
+    "renewable",
     "link",
     "st_storage",
     "load",

--- a/tests/input_converter/test_converter.py
+++ b/tests/input_converter/test_converter.py
@@ -635,6 +635,71 @@ class TestConverter:
         assert thermals_components == expected_thermals_components
         assert thermals_connections == expected_thermals_connections
 
+    def test_convert_renewables_to_component(
+        self, local_study_with_renewable: Study, lib_id: str
+    ):
+        # This test is on the inner function _convert_model_to_component_list, no need to pass a model_list to the converter constructor
+        converter = self._init_converter_from_study(
+            local_study_with_renewable, model_list=[]
+        )
+        path_load = RESOURCES_FOLDER / "renewable.yaml"
+
+        with path_load.open() as template:
+            resource_content = parse_conversion_template(template)
+
+        (
+            renewables_components,
+            renewables_connections,
+            _,
+        ) = converter._convert_model_to_component_list(resource_content)
+
+        available_power_path = "available_power_fr_renewable_generation"
+        expected_renewables_connections = [
+            PortConnectionsSchema(
+                component1="fr_renewable_generation",
+                port1="balance_port",
+                component2="fr_node",
+                port2="balance_port",
+            )
+        ]
+        expected_renewables_component = [
+            ComponentSchema(
+                id="fr_renewable_generation",
+                model=f"{lib_id}.renewable",
+                scenario_group=None,
+                parameters=[
+                    ComponentParameterSchema(
+                        id="nominal_capacity",
+                        time_dependent=False,
+                        scenario_dependent=False,
+                        scenario_group=None,
+                        value=0.0,
+                    ),
+                    ComponentParameterSchema(
+                        id="num_units",
+                        time_dependent=False,
+                        scenario_dependent=False,
+                        scenario_group=None,
+                        value=1,
+                    ),
+                    ComponentParameterSchema(
+                        id="available_power",
+                        time_dependent=True,
+                        scenario_dependent=True,
+                        scenario_group=None,
+                        value=available_power_path,
+                    ),
+                ],
+                properties=[
+                    ComponentPropertySchema(id="carrier", value="electricity"),
+                    ComponentPropertySchema(id="technology", value="other res 1"),
+                ],
+            )
+        ]
+
+        assert renewables_components == expected_renewables_component
+        assert renewables_connections == expected_renewables_connections
+
     def test_convert_hydro_to_component(
         self,
         local_study_with_hydro: Study,

--- a/tests/input_converter/test_converter.py
+++ b/tests/input_converter/test_converter.py
@@ -717,11 +717,13 @@ class TestConverter:
                 ts_interpretation=TimeSeriesInterpretation.PRODUCTION_FACTOR,
             ),
         )
-        local_study_w_thermal.get_areas()["fr"].get_renewables()[
-            "wind_pf"
-        ].set_series(pd.DataFrame(create_dataframe_from_constant(lines=8760, value=1)))
+        local_study_w_thermal.get_areas()["fr"].get_renewables()["wind_pf"].set_series(
+            pd.DataFrame(create_dataframe_from_constant(lines=8760, value=1))
+        )
 
-        converter = self._init_converter_from_study(local_study_w_thermal, model_list=[])
+        converter = self._init_converter_from_study(
+            local_study_w_thermal, model_list=[]
+        )
         path_load = RESOURCES_FOLDER / "renewable.yaml"
         with path_load.open() as template:
             resource_content = parse_conversion_template(template)
@@ -745,6 +747,40 @@ class TestConverter:
         written_series = pd.read_csv(series_path, sep="\t", header=None)
         # factor 1.0 * nominal_capacity 150 * unit_count 3 = 450 MW
         assert (written_series == 450.0).all().all()
+
+    def test_convert_disabled_renewable_is_skipped(
+        self, local_study_w_thermal: Study, caplog: pytest.LogCaptureFixture
+    ):
+        local_study_w_thermal.get_areas()["fr"].create_renewable_cluster(
+            "disabled_wind",
+            RenewableClusterProperties(
+                enabled=False, unit_count=1, nominal_capacity=100.0
+            ),
+        )
+        local_study_w_thermal.get_areas()["fr"].get_renewables()[
+            "disabled_wind"
+        ].set_series(create_dataframe_from_constant(lines=8760))
+
+        converter = self._init_converter_from_study(
+            local_study_w_thermal, model_list=[]
+        )
+        path_load = RESOURCES_FOLDER / "renewable.yaml"
+        with path_load.open() as template:
+            resource_content = parse_conversion_template(template)
+
+        with caplog.at_level("WARNING"):
+            (renewables_components, _, _) = converter._convert_model_to_component_list(
+                resource_content
+            )
+
+        assert all(
+            component.id != "fr_renewable_disabled_wind"
+            for component in renewables_components
+        )
+        assert any(
+            "disabled_wind" in record.message and "disabled" in record.message
+            for record in caplog.records
+        )
 
     def test_convert_hydro_to_component(
         self,

--- a/tests/input_converter/test_converter.py
+++ b/tests/input_converter/test_converter.py
@@ -15,6 +15,10 @@ from pathlib import Path
 
 import pandas as pd
 import pytest
+from antares.craft.model.renewable import (
+    RenewableClusterProperties,
+    TimeSeriesInterpretation,
+)
 from antares.craft.model.study import Study
 
 from antares_gems_converter.input_converter.src.config import MODEL_NAME_TO_FILE_NAME
@@ -699,6 +703,48 @@ class TestConverter:
 
         assert renewables_components == expected_renewables_component
         assert renewables_connections == expected_renewables_connections
+
+    def test_convert_renewables_to_component_production_factor(
+        self, local_study_w_thermal: Study
+    ):
+        # A "production-factor" cluster's series is a [0, 1] availability factor,
+        # not a power value: the converter must scale it by nominal_capacity * unit_count.
+        local_study_w_thermal.get_areas()["fr"].create_renewable_cluster(
+            "wind_pf",
+            RenewableClusterProperties(
+                unit_count=3,
+                nominal_capacity=150.0,
+                ts_interpretation=TimeSeriesInterpretation.PRODUCTION_FACTOR,
+            ),
+        )
+        local_study_w_thermal.get_areas()["fr"].get_renewables()[
+            "wind_pf"
+        ].set_series(pd.DataFrame(create_dataframe_from_constant(lines=8760, value=1)))
+
+        converter = self._init_converter_from_study(local_study_w_thermal, model_list=[])
+        path_load = RESOURCES_FOLDER / "renewable.yaml"
+        with path_load.open() as template:
+            resource_content = parse_conversion_template(template)
+
+        (renewables_components, _, _) = converter._convert_model_to_component_list(
+            resource_content
+        )
+
+        available_power_param = next(
+            param
+            for component in renewables_components
+            for param in component.parameters
+            if param.id == "available_power"
+        )
+        series_path = (
+            converter.output_folder
+            / "input"
+            / "data-series"
+            / f"{available_power_param.value}.tsv"
+        )
+        written_series = pd.read_csv(series_path, sep="\t", header=None)
+        # factor 1.0 * nominal_capacity 150 * unit_count 3 = 450 MW
+        assert (written_series == 450.0).all().all()
 
     def test_convert_hydro_to_component(
         self,


### PR DESCRIPTION
## A2G-02

## Description

Adds conversion support for Antares Simulator **renewable clusters** (wind/solar/other RES groups defined via `renewables/clusters/<area>/list.ini`). Previously, the `"renewable"` cluster type was scaffolded into `config.py`'s generic lookup tables from the project's first commit but was never wired up end-to-end — no conversion template existed, and `ALLOWED_TYPES` in `parsing.py` was missing `"renewable"`, so any attempt to convert one would have raised `ValueError: Unknown value type`.

- **New `renewable.yaml` conversion template** (`data/model_configuration/renewable.yaml`), following the same cluster-type pattern as `thermal.yaml`/`st-storage.yaml`. Maps `nominal_capacity`, `unit_count` → `num_units`, and the availability series → `available_power`, plus `carrier`/`technology` properties — onto the existing `antares_legacy_models.renewable` GEMS model. No changes to the library model itself.
- **`ts-interpretation` correctness fix**: Antares renewable clusters express their series as either `power-generation` (raw MW) or `production-factor` (a `[0,1]` fraction of installed capacity). The converter now scales `production-factor` series by `nominal_capacity × unit_count` before they reach the GEMS model, in a dedicated `_apply_renewable_ts_interpretation` helper in `preprocessing.py`.
- **Disabled-cluster handling**: a disabled renewable cluster (`enabled = False`) contributes zero generation in the original Antares simulation. The converter now skips conversion for disabled renewable clusters and logs a warning, rather than silently emitting an always-on GEMS component that would diverge from the original study's behavior.

Type of change: **Converter — Minor** (new feature + bug fixes). No changes to `antares_legacy_models.yml` itself, so no library version bump needed.

## Impact Analysis

Touches `config.py`, `parsing.py`, `converter.py`, `preprocessing.py`, and adds `renewable.yaml`. Both fixes are scoped by `type_resource`/`cluster_type == "renewable"`; thermal/st_storage paths verified unchanged.

No breaking changes, but note: studies with renewable clusters will now produce components they didn't before (renewable wasn't in the default conversion set previously) — intended, not a regression.

## Checklist

- [x] Solver equivalence tests pass (`pytest tests/antares_historic/`)
- [x] `pyproject.toml` version bumped if converter logic changed
- [x] Changelog entry added if library changed (`CHANGELOG-antares_legacy_models_library.md`)
- [x] `COMPATIBILITY.md` updated if supported versions changed
- [x] Documentation updated or confirmed up to date
- [x] `AGENTS.md` reviewed for impact and updated if needed
