### PR TITLE
Fix catalog to adapt to GEMS views builder catalog schema

### DIFF
--- a/src/antares_gems_converter/catalogs/antares_legacy_area_catalog.yml
+++ b/src/antares_gems_converter/catalogs/antares_legacy_area_catalog.yml
@@ -1,5 +1,4 @@
 catalog:
-  
   id: antares_area_metrics
 
   taxonomy: antares_legacy_taxonomy
@@ -7,389 +6,386 @@ catalog:
   location:
     taxonomy-category: balance
 
-  metrics-definition: 
+  metrics-definition:
+    - id: OV.COST
+      terms:
+        - taxonomy-category: balance
+          output-id: imbalance_cost
+          location-port: null
+        - taxonomy-category: dispatchable_generation
+          output-id: prop_cost
+          location-port: balance_port
+        - taxonomy-category: dispatchable_generation
+          output-id: non_prop_cost
+          location-port: balance_port
+      terms-operator: sum
+      time-operator: sum
 
-  - id: OV.COST
-    terms:
-      - taxonomy-category: balance
-        output-id: imbalance_cost
-        location-ports: null 
-      - taxonomy-category: dispatchable_generation
-        output-id: prop_cost
-        location-ports: balance_port
-      - taxonomy-category: dispatchable_generation
-        output-id: non_prop_cost
-        location-ports: balance_port
-    terms-operator: sum
-    time-operator: sum
+    - id: OP.COST
+      terms:
+        - taxonomy-category: dispatchable_generation
+          output-id: prop_cost
+          location-port: balance_port
+        - taxonomy-category: dispatchable_generation
+          output-id: non_prop_cost
+          location-port: balance_port
+      terms-operator: sum
+      time-operator: sum
 
+    - id: MRG.PRICE
+      terms:
+        - taxonomy-category: balance
+          output-id: price
+          location-port: null
+      terms-operator: avg
+      time-operator: avg
 
-  - id: OP.COST
-    terms:
-      - taxonomy-category: dispatchable_generation
-        output-id: prop_cost
-        location-ports: balance_port
-      - taxonomy-category: dispatchable_generation
-        output-id: non_prop_cost
-        location-ports: balance_port
-    terms-operator: sum
-    time-operator: sum
+    - id: CO2.EMIS
+      terms:
+        - taxonomy-category: dispatchable_generation
+          output-id: co2_emissions
+          location-port: balance_port
+      terms-operator: sum
+      time-operator: sum
 
-  - id: MRG.PRICE
-    terms:
-      - taxonomy-category: balance
-        output-id: price
-        location-ports: null
-    terms-operator: avg
-    time-operator: avg
+    - id: NH3.EMIS
+      terms:
+        - taxonomy-category: dispatchable_generation
+          output-id: nh3_emissions
+          location-port: balance_port
+      terms-operator: sum
+      time-operator: sum
 
-  - id: CO2.EMIS
-    terms:
-      - taxonomy-category: dispatchable_generation
-        output-id: co2_emissions
-        location-ports: balance_port
-    terms-operator: sum
-    time-operator: sum
-  
-  - id: NH3.EMIS
-    terms:
-      - taxonomy-category: dispatchable_generation
-        output-id: nh3_emissions
-        location-ports: balance_port
-    terms-operator: sum
-    time-operator: sum
-  
-  - id: SO2.EMIS
-    terms:
-      - taxonomy-category: dispatchable_generation
-        output-id: so2_emissions
-        location-ports: balance_port
-    terms-operator: sum
-    time-operator: sum
-  
-  - id: NOX.EMIS
-    terms:
-      - taxonomy-category: dispatchable_generation
-        output-id: nox_emissions
-        location-ports: balance_port
-    terms-operator: sum
-    time-operator: sum
-  
-  - id: PM2_5.EMIS
-    terms:
-      - taxonomy-category: dispatchable_generation
-        output-id: pm2_5_emissions
-        location-ports: balance_port
-    terms-operator: sum
-    time-operator: sum
-  
-  - id: PM5.EMIS
-    terms:
-      - taxonomy-category: dispatchable_generation
-        output-id: pm5_emissions
-        location-ports: balance_port
-    terms-operator: sum
-    time-operator: sum
-  
-  - id: PM10.EMIS
-    terms:
-      - taxonomy-category: dispatchable_generation
-        output-id: pm10_emissions
-        location-ports: balance_port
-    terms-operator: sum
-    time-operator: sum
-  
-  - id: NMVOC.EMIS
-    terms:
-      - taxonomy-category: dispatchable_generation
-        output-id: nmvoc_emissions
-        location-ports: balance_port
-    terms-operator: sum
-    time-operator: sum
+    - id: SO2.EMIS
+      terms:
+        - taxonomy-category: dispatchable_generation
+          output-id: so2_emissions
+          location-port: balance_port
+      terms-operator: sum
+      time-operator: sum
 
-  - id: OP1.EMIS
-    terms:
-      - taxonomy-category: dispatchable_generation
-        output-id: op1_emissions
-        location-ports: balance_port
-    terms-operator: sum
-    time-operator: sum
-  
-  - id: OP2.EMIS
-    terms:
-      - taxonomy-category: dispatchable_generation
-        output-id: op2_emissions
-        location-ports: balance_port
-    terms-operator: sum
-    time-operator: sum
-  
-  - id: OP3.EMIS
-    terms:
-      - taxonomy-category: dispatchable_generation
-        output-id: op3_emissions
-        location-ports: balance_port
-    terms-operator: sum
-    time-operator: sum
+    - id: NOX.EMIS
+      terms:
+        - taxonomy-category: dispatchable_generation
+          output-id: nox_emissions
+          location-port: balance_port
+      terms-operator: sum
+      time-operator: sum
 
-  - id: OP4.EMIS
-    terms:
-      - taxonomy-category: dispatchable_generation
-        output-id: op4_emissions
-        location-ports: balance_port
-    terms-operator: sum
-    time-operator: sum
-  
-  - id: OP5.EMIS
-    terms:
-      - taxonomy-category: dispatchable_generation
-        output-id: op5_emissions
-        location-ports: balance_port
-    terms-operator: sum
-    time-operator: sum
+    - id: PM2_5.EMIS
+      terms:
+        - taxonomy-category: dispatchable_generation
+          output-id: pm2_5_emissions
+          location-port: balance_port
+      terms-operator: sum
+      time-operator: sum
 
-  - id: LOAD
-    terms:
-      - taxonomy-category: fatal_consumption
-        output-id: actual_load
-        location-ports: balance_port
-    terms-operator: sum
-    time-operator: sum
-  
-  - id: RES.LOAD
-    terms:
-      - taxonomy-category: fatal_consumption
-        output-id: actual_load
-        location-ports: balance_port
-      - taxonomy-category: renewable_fatal_generation
-        output-id: minus_generation
-        location-ports: balance_port
-      - taxonomy-category: miscellaneous_fatal_generation
-        output-id: minus_generation
-        location-ports: balance_port
-    terms-operator: sum
-    time-operator: sum
+    - id: PM5.EMIS
+      terms:
+        - taxonomy-category: dispatchable_generation
+          output-id: pm5_emissions
+          location-port: balance_port
+      terms-operator: sum
+      time-operator: sum
 
-  - id: DTG.BY.TECHNOLOGY
-    terms:
-      - taxonomy-category: dispatchable_generation
-        output-id: generation_power
-        location-ports: balance_port
-    terms-operator: sum
-    breakdown:
-      - key: technology
-    time-operator: sum
+    - id: PM10.EMIS
+      terms:
+        - taxonomy-category: dispatchable_generation
+          output-id: pm10_emissions
+          location-port: balance_port
+      terms-operator: sum
+      time-operator: sum
 
-  - id: BALANCE
-    terms:
-      - taxonomy-category: link
-        output-id: minus_flow
-        location-ports: out_port
-      - taxonomy-category: link
-        output-id: flow
-        location-ports: in_port
-    terms-operator: sum
-    time-operator: sum
+    - id: NMVOC.EMIS
+      terms:
+        - taxonomy-category: dispatchable_generation
+          output-id: nmvoc_emissions
+          location-port: balance_port
+      terms-operator: sum
+      time-operator: sum
 
-  - id: RES.GENERATION
-    terms:
-      - taxonomy-category: renewable_fatal_generation
-        output-id: generation_power
-        location-ports: balance_port
-    breakdown:
-      - key: technology
-    terms-operator: sum
-    time-operator: sum
+    - id: OP1.EMIS
+      terms:
+        - taxonomy-category: dispatchable_generation
+          output-id: op1_emissions
+          location-port: balance_port
+      terms-operator: sum
+      time-operator: sum
 
-  - id: STS.INJECTION
-    terms:
-      - taxonomy-category: short_term_storage
-        output-id: injection_power
-        location-ports: balance_port
-    breakdown:
-      - key: group
-    terms-operator: sum
-    time-operator: sum
+    - id: OP2.EMIS
+      terms:
+        - taxonomy-category: dispatchable_generation
+          output-id: op2_emissions
+          location-port: balance_port
+      terms-operator: sum
+      time-operator: sum
 
-  - id: STS.WITHDRAWAL
-    terms:
-      - taxonomy-category: short_term_storage
-        output-id: withdrawal_power
-        location-ports: balance_port
-    breakdown:
-      - key: group
-    terms-operator: sum
-    time-operator: sum
+    - id: OP3.EMIS
+      terms:
+        - taxonomy-category: dispatchable_generation
+          output-id: op3_emissions
+          location-port: balance_port
+      terms-operator: sum
+      time-operator: sum
 
-  - id: STS.LEVEL
-    terms:
-      - taxonomy-category: short_term_storage
-        output-id: level
-        location-ports: balance_port
-    breakdown:
-      - key: group
-    terms-operator: avg
-    time-operator: avg
+    - id: OP4.EMIS
+      terms:
+        - taxonomy-category: dispatchable_generation
+          output-id: op4_emissions
+          location-port: balance_port
+      terms-operator: sum
+      time-operator: sum
 
-  - id: UNSP.ENRG
-    terms:
-      - taxonomy-category: balance
-        output-id: unsupplied_energy
-        location-ports: null
-    terms-operator: sum
-    time-operator: sum
+    - id: OP5.EMIS
+      terms:
+        - taxonomy-category: dispatchable_generation
+          output-id: op5_emissions
+          location-port: balance_port
+      terms-operator: sum
+      time-operator: sum
 
-  - id: SPIL.ENRG
-    terms:
-      - taxonomy-category: balance
-        output-id: spilled_energy
-        location-ports: null
-    terms-operator: sum
-    time-operator: sum
+    - id: LOAD
+      terms:
+        - taxonomy-category: fatal_consumption
+          output-id: actual_load
+          location-port: balance_port
+      terms-operator: sum
+      time-operator: sum
 
-  - id: NODU 
-    terms:
-      - taxonomy-category: dispatchable_generation
-        output-id: actual_num_units_on
-        location-ports: balance_port
-    terms-operator: sum
-    time-operator: sum
+    - id: RES.LOAD
+      terms:
+        - taxonomy-category: fatal_consumption
+          output-id: actual_load
+          location-port: balance_port
+        - taxonomy-category: renewable_fatal_generation
+          output-id: minus_generation
+          location-port: balance_port
+        - taxonomy-category: miscellaneous_fatal_generation
+          output-id: minus_generation
+          location-port: balance_port
+      terms-operator: sum
+      time-operator: sum
 
-  - id: NP.COST 
-    terms:
-      - taxonomy-category: dispatchable_generation
-        output-id: non_prop_cost
-        location-ports: balance_port
-    terms-operator: sum
-    time-operator: sum
+    - id: DTG.BY.TECHNOLOGY
+      terms:
+        - taxonomy-category: dispatchable_generation
+          output-id: generation_power
+          location-port: balance_port
+      terms-operator: sum
+      breakdown:
+        - key: technology
+      time-operator: sum
 
-  - id: AVL.DTG
-    terms:
-      - taxonomy-category: dispatchable_generation
-        output-id: cluster_availability
-        location-ports: balance_port
-    terms-operator: sum
-    time-operator: sum
+    - id: BALANCE
+      terms:
+        - taxonomy-category: link
+          output-id: minus_flow
+          location-port: out_port
+        - taxonomy-category: link
+          output-id: flow
+          location-port: in_port
+      terms-operator: sum
+      time-operator: sum
 
-  - id: DTG.MRG
-    terms:
-      - taxonomy-category: dispatchable_generation
-        output-id: up_margin
-        location-ports: balance_port
-    terms-operator: sum
-    time-operator: sum
+    - id: RES.GENERATION
+      terms:
+        - taxonomy-category: renewable_fatal_generation
+          output-id: generation_power
+          location-port: balance_port
+      breakdown:
+        - key: technology
+      terms-operator: sum
+      time-operator: sum
 
-  - id: LOLD
-    terms:
-      - taxonomy-category: balance
-        output-id: is_significant_loss_of_load
-        location-ports: null
-    terms-operator: sum
-    time-operator: sum
+    - id: STS.INJECTION
+      terms:
+        - taxonomy-category: short_term_storage
+          output-id: injection_power
+          location-port: balance_port
+      breakdown:
+        - key: group
+      terms-operator: sum
+      time-operator: sum
 
-  - id: LOLP
-    terms:
-      - taxonomy-category: balance
-        output-id: is_loss_of_load
-        location-ports: null
-    terms-operator: avg
-    time-operator: avg
+    - id: STS.WITHDRAWAL
+      terms:
+        - taxonomy-category: short_term_storage
+          output-id: withdrawal_power
+          location-port: balance_port
+      breakdown:
+        - key: group
+      terms-operator: sum
+      time-operator: sum
 
-  - id: NPCAP.HOURS 
-    terms:
-      - taxonomy-category: balance
-        output-id: is_near_loss_of_load
-        location-ports: null
-    terms-operator: sum
-    time-operator: sum
+    - id: STS.LEVEL
+      terms:
+        - taxonomy-category: short_term_storage
+          output-id: level
+          location-port: balance_port
+      breakdown:
+        - key: group
+      terms-operator: avg
+      time-operator: avg
 
-  - id: ROW.BAL
-    terms:
-      - taxonomy-category: miscellaneous_fatal_generation
-        output-id: generation_power
-        location-ports: balance_port
-    filter:
-      key: miscellaneous_type
-      value: rest_world
-    terms-operator: sum
-    time-operator: sum
+    - id: UNSP.ENRG
+      terms:
+        - taxonomy-category: balance
+          output-id: unsupplied_energy
+          location-port: null
+      terms-operator: sum
+      time-operator: sum
 
-  - id: MISC.NDG 
-    terms:
-      - taxonomy-category: miscellaneous_fatal_generation
-        output-id: generation_power
-        location-ports: balance_port
-    filter: 
-      key: miscellaneous_type
-      value: misc_ndg
-    terms-operator: sum
-    time-operator: sum
-  
-  - id: PSP 
-    terms:
-      - taxonomy-category: miscellaneous_fatal_generation
-        output-id: generation_power
-        location-ports: balance_port
-    filter: 
-      key: miscellaneous_type
-      value: pumped_storage_power
-    terms-operator: sum
-    time-operator: sum
+    - id: SPIL.ENRG
+      terms:
+        - taxonomy-category: balance
+          output-id: spilled_energy
+          location-port: null
+      terms-operator: sum
+      time-operator: sum
 
-  - id: H.STOR
-    terms:
-      - taxonomy-category: long_term_storage
-        output-id: withdrawal_power
-        location-ports: balance_port
-    terms-operator: sum
-    time-operator: sum
+    - id: NODU
+      terms:
+        - taxonomy-category: dispatchable_generation
+          output-id: actual_num_units_on
+          location-port: balance_port
+      terms-operator: sum
+      time-operator: sum
 
-  - id: H.PUMP
-    terms:
-      - taxonomy-category: long_term_storage
-        output-id: injection_power
-        location-ports: balance_port
-    terms-operator: sum
-    time-operator: sum
+    - id: NP.COST
+      terms:
+        - taxonomy-category: dispatchable_generation
+          output-id: non_prop_cost
+          location-port: balance_port
+      terms-operator: sum
+      time-operator: sum
 
-  - id: H.OVFL
-    terms:
-      - taxonomy-category: long_term_storage
-        output-id: overflow
-        location-ports: balance_port
-    terms-operator: sum
-    time-operator: sum
-  
-  - id: H.INFL
-    terms:
-      - taxonomy-category: long_term_storage
-        output-id: actual_inflows
-        location-ports: balance_port
-    terms-operator: sum
-    time-operator: sum
-  
-  - id: H.LEV
-    terms:
-      - taxonomy-category: long_term_storage
-        output-id: level_percentage
-        location-ports: balance_port
-    terms-operator: avg
-    time-operator: avg
+    - id: AVL.DTG
+      terms:
+        - taxonomy-category: dispatchable_generation
+          output-id: cluster_availability
+          location-port: balance_port
+      terms-operator: sum
+      time-operator: sum
 
-  - id: H.VAL # WARNING : metric different from the one in Antares
-    terms:
-      - taxonomy-category: long_term_storage_with_watervalues
-        output-id: hydro_shadow_price
-        location-ports: balance_port
-    terms-operator: avg
-    time-operator: avg
+    - id: DTG.MRG
+      terms:
+        - taxonomy-category: dispatchable_generation
+          output-id: up_margin
+          location-port: balance_port
+      terms-operator: sum
+      time-operator: sum
 
-  - id: H.COST # WARNING : metric different from the one in Antares
-    terms:
-      - taxonomy-category: long_term_storage_with_watervalues
-        output-id: bellman_value
-        location-ports: balance_port
-    terms-operator: sum
-    time-operator: sum
-  
+    - id: LOLD
+      terms:
+        - taxonomy-category: balance
+          output-id: is_significant_loss_of_load
+          location-port: null
+      terms-operator: sum
+      time-operator: sum
+
+    - id: LOLP
+      terms:
+        - taxonomy-category: balance
+          output-id: is_loss_of_load
+          location-port: null
+      terms-operator: avg
+      time-operator: avg
+
+    - id: NPCAP.HOURS
+      terms:
+        - taxonomy-category: balance
+          output-id: is_near_loss_of_load
+          location-port: null
+      terms-operator: sum
+      time-operator: sum
+
+    - id: ROW.BAL
+      terms:
+        - taxonomy-category: miscellaneous_fatal_generation
+          output-id: generation_power
+          location-port: balance_port
+      filter:
+        key: miscellaneous_type
+        value: rest_world
+      terms-operator: sum
+      time-operator: sum
+
+    - id: MISC.NDG
+      terms:
+        - taxonomy-category: miscellaneous_fatal_generation
+          output-id: generation_power
+          location-port: balance_port
+      filter:
+        key: miscellaneous_type
+        value: misc_ndg
+      terms-operator: sum
+      time-operator: sum
+
+    - id: PSP
+      terms:
+        - taxonomy-category: miscellaneous_fatal_generation
+          output-id: generation_power
+          location-port: balance_port
+      filter:
+        key: miscellaneous_type
+        value: pumped_storage_power
+      terms-operator: sum
+      time-operator: sum
+
+    - id: H.STOR
+      terms:
+        - taxonomy-category: long_term_storage
+          output-id: withdrawal_power
+          location-port: balance_port
+      terms-operator: sum
+      time-operator: sum
+
+    - id: H.PUMP
+      terms:
+        - taxonomy-category: long_term_storage
+          output-id: injection_power
+          location-port: balance_port
+      terms-operator: sum
+      time-operator: sum
+
+    - id: H.OVFL
+      terms:
+        - taxonomy-category: long_term_storage
+          output-id: overflow
+          location-port: balance_port
+      terms-operator: sum
+      time-operator: sum
+
+    - id: H.INFL
+      terms:
+        - taxonomy-category: long_term_storage
+          output-id: actual_inflows
+          location-port: balance_port
+      terms-operator: sum
+      time-operator: sum
+
+    - id: H.LEV
+      terms:
+        - taxonomy-category: long_term_storage
+          output-id: level_percentage
+          location-port: balance_port
+      terms-operator: avg
+      time-operator: avg
+
+    - id: H.VAL # WARNING : metric different from the one in Antares
+      terms:
+        - taxonomy-category: long_term_storage_with_watervalues
+          output-id: hydro_shadow_price
+          location-port: balance_port
+      terms-operator: avg
+      time-operator: avg
+
+    - id: H.COST # WARNING : metric different from the one in Antares
+      terms:
+        - taxonomy-category: long_term_storage_with_watervalues
+          output-id: bellman_value
+          location-port: balance_port
+      terms-operator: sum
+      time-operator: sum
+
   # - id: MAX.MRG # TODO : traat as a postreatment. Calulation from hour to hour can differ for this metric max-mrg-utilis.cpp in Simulator, there is an algorithm to compute this metric.
-  

--- a/src/antares_gems_converter/catalogs/antares_legacy_link_catalog.yml
+++ b/src/antares_gems_converter/catalogs/antares_legacy_link_catalog.yml
@@ -1,8 +1,7 @@
 catalog:
-
   # TO DO : this catalog should be improved, correctness of the Metrics should be checked
   # Remark for the case of CONG.FEE.ABS : We will probably need a new operator in the GEMS grammar: using ports exporting extra-outputs to other components.
-  
+
   id: antares_link_metrics
 
   taxonomy: antares_legacy_taxonomy
@@ -10,78 +9,77 @@ catalog:
   location:
     taxonomy-category: link
 
-  metrics-definition: 
+  metrics-definition:
+    - id: FLOW.LIN
+      terms:
+        - taxonomy-category: link
+          output-id: flow
+          location-port: null
+      terms-operator: sum
+      time-operator: sum
 
-  - id: FLOW.LIN
-    terms:
-      - taxonomy-category: link
-        output-id: flow
-        location-ports: null 
-    terms-operator: sum
-    time-operator: sum
-  
-  - id: UCAP.LIN
-    terms:
-      - taxonomy-category: link
-        output-id: abs_flow
-        location-ports: null 
-    terms-operator: sum
-    time-operator: sum
+    - id: UCAP.LIN
+      terms:
+        - taxonomy-category: link
+          output-id: abs_flow
+          location-port: null
+      terms-operator: sum
+      time-operator: sum
 
-  - id: CONG.FEE.ABS
-    terms:
-      - taxonomy-category: link
-        output-id: abs_congestion_fee
-        location-ports: null 
-    terms-operator: sum
-    time-operator: sum
+    - id: CONG.FEE.ABS
+      terms:
+        - taxonomy-category: link
+          output-id: abs_congestion_fee
+          location-port: null
+      terms-operator: sum
+      time-operator: sum
 
-  - id: CONG.FEE.ALG
-    terms:
-      - taxonomy-category: link
-        output-id: alg_congestion_fee
-        location-ports: null 
-    terms-operator: sum
-    time-operator: sum
+    - id: CONG.FEE.ALG
+      terms:
+        - taxonomy-category: link
+          output-id: alg_congestion_fee
+          location-port: null
+      terms-operator: sum
+      time-operator: sum
 
-  - id: MARG.COST
-    terms:
-      - taxonomy-category: link
-        output-id: capacity_shadow_price
-        location-ports: null 
-    terms-operator: sum
-    time-operator: sum
+    - id: MARG.COST
+      terms:
+        - taxonomy-category: link
+          output-id: capacity_shadow_price
+          location-port: null
+      terms-operator: sum
+      time-operator: sum
 
-  - id: CONG.PROB.DIR
-    terms:
-      - taxonomy-category: link
-        output-id: is_directly_congested
-        location-ports: null 
-    terms-operator: sum
-    time-operator: sum
+    - id: CONG.PROB.DIR
+      terms:
+        - taxonomy-category: link
+          output-id: is_directly_congested
+          location-port: null
+      terms-operator: sum
+      time-operator: sum
 
-  - id: CONG.PROB.INDIR
-    terms:
-      - taxonomy-category: link
-        output-id: is_indirectly_congested
-        location-ports: null 
-    terms-operator: sum
-    time-operator: sum
+    - id: CONG.PROB.INDIR
+      terms:
+        - taxonomy-category: link
+          output-id: is_indirectly_congested
+          location-port: null
+      terms-operator: sum
+      time-operator: sum
 
-  - id: HURDLE.COST
-    terms:
-      - taxonomy-category: link
-        output-id: prop_cost
-        location-ports: null 
-    terms-operator: sum
-    time-operator: sum
+    - id: HURDLE.COST
+      terms:
+        - taxonomy-category: link
+          output-id: prop_cost
+          location-port: null
+      terms-operator: sum
+      time-operator: sum
 
-  - id: LOOP.FLOW
-    terms:
-      - taxonomy-category: link
-        output-id: actual_loop_flow
-        location-ports: null 
-    terms-operator: sum
-    time-operator: sum
+    - id: LOOP.FLOW
+      terms:
+        - taxonomy-category: link
+          output-id: actual_loop_flow
+          location-port: null
+      terms-operator: sum
+      time-operator: sum
 
-  # - id: FLOW.QUAD # à déprécier 
+  # - id: FLOW.QUAD # à déprécier

--- a/src/antares_gems_converter/catalogs/antares_legacy_short_term_storage_catalog.yml
+++ b/src/antares_gems_converter/catalogs/antares_legacy_short_term_storage_catalog.yml
@@ -1,5 +1,4 @@
 catalog:
-
   # TO DO : this catalog should be improved, correctness of the Metrics should be checked
 
   id: antares_sts_metrics
@@ -9,36 +8,35 @@ catalog:
   location:
     taxonomy-category: short_term_storage
 
-  metrics-definition: 
+  metrics-definition:
+    - id: P.INJECTION
+      terms:
+        - taxonomy-category: short_term_storage
+          output-id: injection_power
+          location-port: null
+      terms-operator: sum
+      time-operator: sum
 
-  - id: P.INJECTION
-    terms:
-      - taxonomy-category: short_term_storage
-        output-id: injection_power
-        location-ports: null
-    terms-operator: sum
-    time-operator: sum
+    - id: P.WITHDRAWAL
+      terms:
+        - taxonomy-category: short_term_storage
+          output-id: withdrawal_power
+          location-port: null
+      terms-operator: sum
+      time-operator: sum
 
-  - id: P.WITHDRAWAL
-    terms:
-      - taxonomy-category: short_term_storage
-        output-id: withdrawal_power
-        location-ports: null
-    terms-operator: sum
-    time-operator: sum
+    - id: LEVELS
+      terms:
+        - taxonomy-category: short_term_storage
+          output-id: level
+          location-port: null
+      terms-operator: avg
+      time-operator: avg
 
-  - id: LEVELS
-    terms:
-      - taxonomy-category: short_term_storage
-        output-id: level
-        location-ports: null
-    terms-operator: avg
-    time-operator: avg
-  
-  - id: CASHFLOW
-    terms:
-      - taxonomy-category: short_term_storage
-        output-id: profit
-        location-ports: null
-    terms-operator: avg
-    time-operator: avg
+    - id: CASHFLOW
+      terms:
+        - taxonomy-category: short_term_storage
+          output-id: profit
+          location-port: null
+      terms-operator: avg
+      time-operator: avg

--- a/src/antares_gems_converter/catalogs/antares_legacy_thermal_cluster_catalog.yml
+++ b/src/antares_gems_converter/catalogs/antares_legacy_thermal_cluster_catalog.yml
@@ -1,5 +1,4 @@
 catalog:
-  
   id: antares_thermal_cluster_metrics
 
   taxonomy: antares_legacy_taxonomy
@@ -7,44 +6,43 @@ catalog:
   location:
     taxonomy-category: dispatchable_generation
 
-  metrics-definition: 
+  metrics-definition:
+    - id: GENERATION
+      terms:
+        - taxonomy-category: dispatchable_generation
+          output-id: generation_power
+          location-port: null
+      terms-operator: sum
+      time-operator: sum
 
-  - id: GENERATION
-    terms:
-      - taxonomy-category: dispatchable_generation
-        output-id: generation_power
-        location-ports: null
-    terms-operator: sum
-    time-operator: sum
+    - id: MIN.GEN
+      terms:
+        - taxonomy-category: dispatchable_generation
+          output-id: min_gen_power
+          location-port: null
+      terms-operator: sum
+      time-operator: sum
 
-  - id: MIN.GEN
-    terms:
-      - taxonomy-category: dispatchable_generation
-        output-id: min_gen_power
-        location-ports: null
-    terms-operator: sum
-    time-operator: sum
+    - id: PROFIT
+      terms:
+        - taxonomy-category: dispatchable_generation
+          output-id: profit
+          location-port: null
+      terms-operator: sum
+      time-operator: sum
 
-  - id: PROFIT
-    terms:
-      - taxonomy-category: dispatchable_generation
-        output-id: profit 
-        location-ports: null
-    terms-operator: sum
-    time-operator: sum
+    - id: NODU
+      terms:
+        - taxonomy-category: dispatchable_generation
+          output-id: actual_num_units_on
+          location-port: null
+      terms-operator: sum
+      time-operator: sum
 
-  - id: NODU
-    terms:
-      - taxonomy-category: dispatchable_generation
-        output-id: actual_num_units_on
-        location-ports: null
-    terms-operator: sum
-    time-operator: sum
-
-  - id: NP.COST
-    terms:
-      - taxonomy-category: dispatchable_generation
-        output-id: non_prop_cost
-        location-ports: null
-    terms-operator: sum
-    time-operator: sum
+    - id: NP.COST
+      terms:
+        - taxonomy-category: dispatchable_generation
+          output-id: non_prop_cost
+          location-port: null
+      terms-operator: sum
+      time-operator: sum


### PR DESCRIPTION
## Process ID

<!-- Which governance process does this PR fall under? -->
 N/A 

**Process:**

## Description

Update catalog to GEMS view builder parsing scheme

## Impact Analysis

Only impacts catalogs file, no other impact
The only diff in this PR is the renaming `location-ports` -> `location-port`, the rest is pure formatting

## Checklist

- [ ] Solver equivalence tests pass (`pytest tests/antares_historic/`)
- [ ] `pyproject.toml` version bumped if converter logic changed
- [ ] Changelog entry added if library changed (`CHANGELOG-antares_legacy_models_library.md`)
- [ ] `COMPATIBILITY.md` updated if supported versions changed
- [ ] Documentation updated or confirmed up to date
- [ ] `AGENTS.md` reviewed for impact and updated if needed
