### PR TITLE
chore(deps): update antares simulator to 10.1.1 and gemspy to 0.1.3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,12 +189,6 @@ uv sync --group dev
 # Run all tests
 uv run pytest
 
-# Run tests in parallel (pytest-xdist)
-uv run pytest -n auto
-
-# Prefer parallel for unit/integration tests
-uv run pytest tests/input_converter/ -n auto
-
 # Run a specific test
 uv run pytest tests/input_converter/test_converter.py::TestConverter::test_thermal_model_conversion
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -292,7 +292,7 @@ Pinned Python library versions are listed in `pyproject.toml` and `uv.lock` (see
 | Package | Purpose |
 |---------|---------|
 | `antares-craft` | Read/write Antares studies programmatically |
-| `gemspy` | GEMS interpreter — provides `InputSystem`, `InputComponent`, etc. |
+| `gemspy` | GEMS interpreter — top-level packages `gems_craft` (`SystemSchema`, `ComponentSchema`, etc.) and `gems_craft_hybrid` (hybrid-mode-only schemas, e.g. `AreaConnectionsSchema`, `HybridSystemSchema`) |
 | `pydantic` | Data validation for conversion templates and structured data |
 | `pandas` / `numpy` | Timeseries data handling and numerical operations |
 | `PyYAML` | YAML parsing and generation |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,6 +189,12 @@ uv sync --group dev
 # Run all tests
 uv run pytest
 
+# Run tests in parallel (pytest-xdist)
+uv run pytest -n auto
+
+# Prefer parallel for unit/integration tests
+uv run pytest tests/input_converter/ -n auto
+
 # Run a specific test
 uv run pytest tests/input_converter/test_converter.py::TestConverter::test_thermal_model_conversion
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -47,6 +47,7 @@ Runtime and development Python packages are pinned to exact versions in `pyproje
 | PyYAML | 6.0.3 |
 | pytest | 9.0.3 |
 | pytest-cov | 7.1.0 |
+| pytest-xdist | 3.8.0 |
 | mypy | 2.1.0 |
 | types-pyyaml | 6.0.12 |
 | black | 23.7.0 |

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -4,7 +4,7 @@ This table maps converter versions to the tool versions they are compatible with
 
 | Converter | Antares-Simulator | antares-craft | GemsPy | Notes |
 |-----------|-------------------|---------------|--------|-------|
-| 0.3.0     | 10.1.0            | 0.15.1        | 0.1.2  | antares-craft 0.15.1 (bug fix: districts issue in area deletion; unused read_outputs_api/local methods added) |
+| 0.3.0     | 10.1.1            | 0.15.1        | 0.1.3  | GemsPy 0.1.3 (top-level package renamed `gems` -> `gems_craft`; hybrid-only schemas split into `gems_craft_hybrid`; `parse_yaml_components` renamed to `parse_yaml_system`); Antares-Simulator 10.1.1. antares-craft 0.15.1 (bug fix: districts issue in area deletion; unused read_outputs_api/local methods added) |
 | 0.2.1     | 10.1.0            | 0.14.0        | 0.1.2  | Packaging fix: include missing YAML files (model libraries) in the pip package |
 | 0.2.0     | 10.1.0            | 0.14.0        | 0.1.2  | GemsPy 0.1.2; Antares Legacy Models Library 2.1.2; all component properties now converted via templates (only `electricity` carrier supported)|
 | 0.1.3     | 10.1.0            | 0.14.0        | 0.1.0  | Antares Legacy Models Library 2.1.0: market bid cost in thermal, STS overflow and variation penalties |
@@ -40,7 +40,7 @@ Runtime and development Python packages are pinned to exact versions in `pyproje
 | antares-craft | 0.15.1 |
 | antares-study-version | 1.0.20 |
 | antares-timeseries-generation | 0.1.9 |
-| gemspy | 0.1.2 |
+| gemspy | 0.1.3 |
 | numpy | 2.2.6 |
 | pandas | 2.2.3 |
 | pydantic | 2.11.10 |
@@ -62,6 +62,6 @@ Runtime and development Python packages are pinned to exact versions in `pyproje
 |-----------|----------------|--------------|
 | Converter | 0.3.0 | `pyproject.toml` |
 | Antares Legacy Models Library | 2.1.2 | `src/antares_gems_converter/libs/antares_historic/antares_legacy_models.yml` |
-| Antares-Simulator | 10.1.0 | `dependencies.json` |
+| Antares-Simulator | 10.1.1 | `dependencies.json` |
 | antares-craft | 0.15.1 | `pyproject.toml` |
-| GemsPy | 0.1.2 | `pyproject.toml` |
+| GemsPy | 0.1.3 | `pyproject.toml` |

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -47,7 +47,6 @@ Runtime and development Python packages are pinned to exact versions in `pyproje
 | PyYAML | 6.0.3 |
 | pytest | 9.0.3 |
 | pytest-cov | 7.1.0 |
-| pytest-xdist | 3.8.0 |
 | mypy | 2.1.0 |
 | types-pyyaml | 6.0.12 |
 | black | 23.7.0 |

--- a/dependencies.json
+++ b/dependencies.json
@@ -1,3 +1,3 @@
 {
-  "antares_simulator_version": "10.1.0"
+  "antares_simulator_version": "10.1.1"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,6 @@ antares-to-gems = "antares_gems_converter.input_converter.src.main:main"
 dev = [
     "pytest>=9.0.3",
     "pytest-cov>=7.1.0",
-    "pytest-xdist>=3.8.0",
     "mypy>=2.1.0",
     "types-pyyaml>=6.0.12",
     "black>=23.7.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "numpy>=2.2.6",
     "pandas>=2.2.3",
     "pydantic>=2.11.10",
-    "gemspy==0.1.2",
+    "gemspy==0.1.3",
     "PyYAML>=6.0.3",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ antares-to-gems = "antares_gems_converter.input_converter.src.main:main"
 dev = [
     "pytest>=9.0.3",
     "pytest-cov>=7.1.0",
+    "pytest-xdist>=3.8.0",
     "mypy>=2.1.0",
     "types-pyyaml>=6.0.12",
     "black>=23.7.0",

--- a/src/antares_gems_converter/input_converter/src/converter.py
+++ b/src/antares_gems_converter/input_converter/src/converter.py
@@ -48,14 +48,14 @@ from antares_gems_converter.input_converter.src.utils import (
     read_yaml_file,
     resolve_path,
 )
-from gems.study.parsing import (
-    AreaConnectionsSchema,
+from gems_craft.study.parsing import (
     ComponentParameterSchema,
     ComponentPropertySchema,
     ComponentSchema,
     PortConnectionsSchema,
     SystemSchema,
 )
+from gems_craft_hybrid.study.parsing import AreaConnectionsSchema, HybridSystemSchema
 
 ANTARES_HISTORIC_LIB_ID = "antares_legacy_models"
 MODEL_TEMPLATE_FOLDER = Path(__file__).parents[1] / "data" / "model_configuration"
@@ -494,7 +494,7 @@ class AntaresStudyConverter:
         connections.extend(connections_from_model)
         area_connections.extend(area_connections_from_model)
 
-    def convert_study_to_input_system(self) -> SystemSchema:
+    def convert_study_to_input_system(self) -> HybridSystemSchema:
         self._copy_libs_to_model_librairies()
         self._copy_scenario_builder()
         self._create_dataseries_dir()
@@ -515,14 +515,14 @@ class AntaresStudyConverter:
             )
         if self.mode == ConversionMode.HYBRID:
             self._delete_legacy_objects()
-        system = SystemSchema(
+        system = HybridSystemSchema(
             id=self.study.name,
             components=components,
             connections=connections or None,
             area_connections=area_connections or None,
         )
         data = system.model_dump(exclude_none=True)
-        return SystemSchema(**data)
+        return HybridSystemSchema(**data)
 
     def _build_model_conversion_templates(self) -> dict[str, ConversionTemplate]:
         model_conversion_templates: dict[str, ConversionTemplate] = {}

--- a/src/antares_gems_converter/input_converter/src/converter.py
+++ b/src/antares_gems_converter/input_converter/src/converter.py
@@ -494,7 +494,7 @@ class AntaresStudyConverter:
         connections.extend(connections_from_model)
         area_connections.extend(area_connections_from_model)
 
-    def convert_study_to_input_system(self) -> HybridSystemSchema:
+    def convert_study_to_input_system(self) -> SystemSchema | HybridSystemSchema:
         self._copy_libs_to_model_librairies()
         self._copy_scenario_builder()
         self._create_dataseries_dir()
@@ -515,14 +515,21 @@ class AntaresStudyConverter:
             )
         if self.mode == ConversionMode.HYBRID:
             self._delete_legacy_objects()
-        system = HybridSystemSchema(
+            system = HybridSystemSchema(
+                id=self.study.name,
+                components=components,
+                connections=connections or None,
+                area_connections=area_connections or None,
+            )
+            data = system.model_dump(exclude_none=True)
+            return HybridSystemSchema(**data)
+        system = SystemSchema(
             id=self.study.name,
             components=components,
             connections=connections or None,
-            area_connections=area_connections or None,
         )
         data = system.model_dump(exclude_none=True)
-        return HybridSystemSchema(**data)
+        return SystemSchema(**data)
 
     def _build_model_conversion_templates(self) -> dict[str, ConversionTemplate]:
         model_conversion_templates: dict[str, ConversionTemplate] = {}

--- a/tests/antares_historic/test_model_taxonomy.py
+++ b/tests/antares_historic/test_model_taxonomy.py
@@ -2,8 +2,8 @@ from pathlib import Path
 
 import pytest
 import yaml
-from gems.model.parsing import LibrarySchema
-from gems.model.taxonomy import Taxonomy, check_library_against_taxonomy, load_taxonomy
+from gems_craft.model.parsing import LibrarySchema
+from gems_craft.model.taxonomy import Taxonomy, check_library_against_taxonomy, load_taxonomy
 
 TAXONOMIES_DIR = Path("src/antares_gems_converter/taxonomies")
 MODEL_LIBRARIES_DIR = Path("src/antares_gems_converter/libs")

--- a/tests/input_converter/test_converter.py
+++ b/tests/input_converter/test_converter.py
@@ -112,7 +112,7 @@ class TestConverter:
         converter = self._init_converter_from_study(local_study_w_areas, model_list=[])
         input_study = converter.convert_study_to_input_system()
 
-        expected_input_study = HybridSystemSchema(
+        expected_input_study = SystemSchema(
             id="studyTest",
             components=[
                 ComponentSchema(

--- a/tests/input_converter/test_converter.py
+++ b/tests/input_converter/test_converter.py
@@ -28,17 +28,17 @@ from antares_gems_converter.input_converter.src.utils import (
     check_file_exists,
     dump_to_yaml,
 )
-from gems.model.resolve_library import resolve_library
-from gems.study.parsing import (
-    AreaConnectionsSchema,
+from gems_craft.model.resolve_library import resolve_library
+from gems_craft.study.parsing import (
     ComponentParameterSchema,
     ComponentSchema,
     ComponentPropertySchema,
     PortConnectionsSchema,
     SystemSchema,
-    parse_yaml_components,
+    parse_yaml_system,
 )
-from gems.study.resolve_components import resolve_system
+from gems_craft.study.resolve_components import resolve_system
+from gems_craft_hybrid.study.parsing import AreaConnectionsSchema, HybridSystemSchema
 from tests.input_converter.conftest import create_dataframe_from_constant
 import numpy as np
 
@@ -112,7 +112,7 @@ class TestConverter:
         converter = self._init_converter_from_study(local_study_w_areas, model_list=[])
         input_study = converter.convert_study_to_input_system()
 
-        expected_input_study = SystemSchema(
+        expected_input_study = HybridSystemSchema(
             id="studyTest",
             components=[
                 ComponentSchema(
@@ -238,7 +238,7 @@ class TestConverter:
         dump_to_yaml(model=input_study, output_path=yaml_path)
         # Open yaml file to validate
         with open(yaml_path, "r", encoding="utf-8") as yaml_file:
-            validated_data = parse_yaml_components(yaml_file)
+            validated_data = parse_yaml_system(yaml_file)
 
         expected_validated_data = SystemSchema(
             id="studyTest",
@@ -759,7 +759,7 @@ class TestConverter:
 
         output_path = local_path / "reference.yaml"
         with open(output_path) as system_file:
-            expected_data = parse_yaml_components(system_file)
+            expected_data = parse_yaml_system(system_file)
 
         input_path = tmp_path / "input" / LOCAL_PATH
         output_path = tmp_path / "output" / LOCAL_PATH
@@ -1501,7 +1501,7 @@ class TestConverter:
 
         output_path = local_path / "reference.yaml"
         with open(output_path) as system_file:
-            expected_data = parse_yaml_components(system_file)
+            expected_data = parse_yaml_system(system_file)
 
         input_path = tmp_path / "input" / LOCAL_PATH
         output_path = tmp_path / "output" / LOCAL_PATH
@@ -1597,7 +1597,7 @@ class TestConverter:
 
         output_path = local_path / "reference_hybrid.yaml"
         with open(output_path) as system_file:
-            expected_data = parse_yaml_components(system_file)
+            expected_data = parse_yaml_system(system_file, HybridSystemSchema)
 
         model_list: list = ["battery"]
 
@@ -1672,7 +1672,7 @@ class TestConverter:
         )
         obtained_sys = converter.convert_study_to_input_system()
         with open(ref_path) as system_file:
-            expected_sys = parse_yaml_components(system_file)
+            expected_sys = parse_yaml_system(system_file)
         assert obtained_sys.components == expected_sys.components
 
     def test_multiply_operation(self):

--- a/uv.lock
+++ b/uv.lock
@@ -57,7 +57,6 @@ dev = [
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-cov" },
-    { name = "pytest-xdist" },
     { name = "types-pyyaml" },
 ]
 
@@ -79,7 +78,6 @@ dev = [
     { name = "mypy", specifier = ">=2.1.0" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
-    { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "types-pyyaml", specifier = ">=6.0.12" },
 ]
 
@@ -510,15 +508,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5a/d3/8ae2869247df154b64c1884d7346d412fed0c49df84db635aab2d1c40e62/deprecation-2.1.0.tar.gz", hash = "sha256:72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff", size = 173788, upload-time = "2020-04-20T14:23:38.738Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/02/c3/253a89ee03fc9b9682f1541728eb66db7db22148cd94f89ab22528cd1e1b/deprecation-2.1.0-py2.py3-none-any.whl", hash = "sha256:a10811591210e1fb0e768a8c25517cabeabcba6f0bf96564f8ff45189f90b14a", size = 11178, upload-time = "2020-04-20T14:23:36.581Z" },
-]
-
-[[package]]
-name = "execnet"
-version = "2.1.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
 ]
 
 [[package]]
@@ -1203,19 +1192,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
-]
-
-[[package]]
-name = "pytest-xdist"
-version = "3.8.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "execnet" },
-    { name = "pytest" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -57,6 +57,7 @@ dev = [
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "types-pyyaml" },
 ]
 
@@ -78,6 +79,7 @@ dev = [
     { name = "mypy", specifier = ">=2.1.0" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "types-pyyaml", specifier = ">=6.0.12" },
 ]
 
@@ -508,6 +510,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5a/d3/8ae2869247df154b64c1884d7346d412fed0c49df84db635aab2d1c40e62/deprecation-2.1.0.tar.gz", hash = "sha256:72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff", size = 173788, upload-time = "2020-04-20T14:23:38.738Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/02/c3/253a89ee03fc9b9682f1541728eb66db7db22148cd94f89ab22528cd1e1b/deprecation-2.1.0-py2.py3-none-any.whl", hash = "sha256:a10811591210e1fb0e768a8c25517cabeabcba6f0bf96564f8ff45189f90b14a", size = 11178, upload-time = "2020-04-20T14:23:36.581Z" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
 ]
 
 [[package]]
@@ -1192,6 +1203,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -65,7 +65,7 @@ requires-dist = [
     { name = "antares-craft", specifier = "==0.15.1" },
     { name = "antares-study-version", specifier = "==1.0.20" },
     { name = "antares-timeseries-generation", specifier = "==0.1.9" },
-    { name = "gemspy", specifier = "==0.1.2" },
+    { name = "gemspy", specifier = "==0.1.3" },
     { name = "numpy", specifier = ">=2.2.6" },
     { name = "pandas", specifier = ">=2.2.3" },
     { name = "pydantic", specifier = ">=2.11.10" },
@@ -521,7 +521,7 @@ wheels = [
 
 [[package]]
 name = "gemspy"
-version = "0.1.2"
+version = "0.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "antlr4-python3-runtime" },
@@ -535,9 +535,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "xarray" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/8a/4e4285e61e9d6716a19995cf0680373a7ec6dd573a659101b4c61d75043b/gemspy-0.1.2.tar.gz", hash = "sha256:55aeef7ac32f049136d82381d488e03744329ef95489f2562f3cd14b11193487", size = 88370, upload-time = "2026-06-11T12:13:17.994Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/e2/8260139805f657cdd5dd2d5f3e02c974c05e4cd3ac83724b6b759c488892/gemspy-0.1.3.tar.gz", hash = "sha256:49325e19f37be1f1b1dc394fab4f29d85b813a95256a5da62756936100c5341a", size = 90736, upload-time = "2026-07-24T09:54:41.674Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/a5/592b323148996541f80e4e812dddf92982d340afe5e14a765b62b590312c/gemspy-0.1.2-py3-none-any.whl", hash = "sha256:dd4b7b8adb9dfde1e00717f0c92df77725701b9b8bf2e5cc796a03cb594e1c65", size = 114582, upload-time = "2026-06-11T12:13:16.801Z" },
+    { url = "https://files.pythonhosted.org/packages/95/d4/208b59a521ba66f75de1e5757401ce029469e4d537ff559602d670f641b3/gemspy-0.1.3-py3-none-any.whl", hash = "sha256:115dd4b344551ab3e4f6cadc68328e9926d01f1297fe1227e25c61b34aebf0bd", size = 120811, upload-time = "2026-07-24T09:54:40.693Z" },
 ]
 
 [[package]]


### PR DESCRIPTION


Bump dependencies in dependencies.json and pyproject.toml. Update gemspy version in uv.lock and adjust related references in converter.py and test files to reflect the new schema changes.

## Process ID

<!-- Which governance process does this PR fall under? -->
<!-- A2G-01 | A2G-02 | A2G-03 | A2G-04 | N/A -->

**Process:**
Update dependencies.json,pyproject.toml and uv.lock files.
Resolve imports based on new library. 

## Description

<!-- What does this PR change and why? -->
Update version of gemspy and antares simulator

## Impact Analysis

<!-- Which converter modules, models, or studies are affected? -->
<!-- Are there breaking changes to existing study generation? -->

## Checklist

- [x] Solver equivalence tests pass (`pytest tests/antares_historic/`)
- [ ] `pyproject.toml` version bumped if converter logic changed
- [ ] Changelog entry added if library changed (`CHANGELOG-antares_legacy_models_library.md`)
- [ ] `COMPATIBILITY.md` updated if supported versions changed
- [ ] Documentation updated or confirmed up to date
- [ ] `AGENTS.md` reviewed for impact and updated if needed
