### PR TITLE
chore(tests): add pytest-xdist for parallel test runs

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -98,7 +98,7 @@ jobs:
 
       - name: Run tests
         id: run_tests
-        run: uv run pytest --cov=antares_gems_converter --cov=antares_runner --cov-report=xml -v --tb=short
+        run: uv run pytest -n auto --cov=antares_gems_converter --cov=antares_runner --cov-report=xml -v --tb=short
         continue-on-error: true
 
       - name: Upload test artifacts on failure

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,6 +189,12 @@ uv sync --group dev
 # Run all tests
 uv run pytest
 
+# Run tests in parallel (pytest-xdist)
+uv run pytest -n auto
+
+# Prefer parallel for unit/integration tests
+uv run pytest tests/input_converter/ -n auto
+
 # Run a specific test
 uv run pytest tests/input_converter/test_converter.py::TestConverter::test_thermal_model_conversion
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -47,6 +47,7 @@ Runtime and development Python packages are pinned to exact versions in `pyproje
 | PyYAML | 6.0.3 |
 | pytest | 9.0.3 |
 | pytest-cov | 7.1.0 |
+| pytest-xdist | 3.8.0 |
 | mypy | 2.1.0 |
 | types-pyyaml | 6.0.12 |
 | black | 23.7.0 |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ antares-to-gems = "antares_gems_converter.input_converter.src.main:main"
 dev = [
     "pytest>=9.0.3",
     "pytest-cov>=7.1.0",
+    "pytest-xdist>=3.8.0",
     "mypy>=2.1.0",
     "types-pyyaml>=6.0.12",
     "black>=23.7.0",

--- a/uv.lock
+++ b/uv.lock
@@ -57,6 +57,7 @@ dev = [
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "types-pyyaml" },
 ]
 
@@ -78,6 +79,7 @@ dev = [
     { name = "mypy", specifier = ">=2.1.0" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "types-pyyaml", specifier = ">=6.0.12" },
 ]
 
@@ -508,6 +510,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5a/d3/8ae2869247df154b64c1884d7346d412fed0c49df84db635aab2d1c40e62/deprecation-2.1.0.tar.gz", hash = "sha256:72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff", size = 173788, upload-time = "2020-04-20T14:23:38.738Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/02/c3/253a89ee03fc9b9682f1541728eb66db7db22148cd94f89ab22528cd1e1b/deprecation-2.1.0-py2.py3-none-any.whl", hash = "sha256:a10811591210e1fb0e768a8c25517cabeabcba6f0bf96564f8ff45189f90b14a", size = 11178, upload-time = "2020-04-20T14:23:36.581Z" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
 ]
 
 [[package]]
@@ -1192,6 +1203,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Enable pytest-xdist locally and run CI tests with -n auto.

## Process ID

<!-- Which governance process does this PR fall under? -->
<!-- A2G-01 | A2G-02 | A2G-03 | A2G-04 | N/A -->

**Process:**

1. Add new library in pyproject.toml
2. Update uv.lock file 
3. Update CI/CD file 
4. Update AGENTS.md
5. Update Compatibility.md

## Description

<!-- What does this PR change and why? -->
Add pytest-xdist to enable parallel test execution
Main target is to speed up CI/CD pipeline execution ~30minutes currently before changes. 
After changes ~ 15minutes
Locally it reduce tests to ~2 minutes with 14 workers(threads) for my local machine  
## Impact Analysis

<!-- Which converter modules, models, or studies are affected? -->
<!-- Are there breaking changes to existing study generation? -->

## Checklist

- [x] Solver equivalence tests pass (`pytest tests/antares_historic/`)
- [x] `pyproject.toml` version bumped if converter logic changed
- [ ] Changelog entry added if library changed (`CHANGELOG-antares_legacy_models_library.md`)
- [x] `COMPATIBILITY.md` updated if supported versions changed
- [ ] Documentation updated or confirmed up to date
- [x] `AGENTS.md` reviewed for impact and updated if needed
