### PR TITLE
fix(taxonomy): add flattened taxonomy for GEMS view builder compatibility

### DIFF
--- a/src/antares_gems_converter/taxonomies/antares_legacy_taxonomy_flattened.yml
+++ b/src/antares_gems_converter/taxonomies/antares_legacy_taxonomy_flattened.yml
@@ -35,7 +35,8 @@ taxonomy:
         - id: balance_port
 
     - id: dispatchable_generation
-      parent-category: generation
+      ports:
+        - id: balance_port
       variables: 
         - id: generation_power
       extra-outputs:
@@ -63,20 +64,33 @@ taxonomy:
         - id: technology
 
     - id: fatal_generation
-      parent-category: generation
+      ports:
+        - id: balance_port
       parameters:
         - id: available_power
       extra-outputs:
         - id: minus_generation
         - id: generation_power
-    
+
     - id: renewable_fatal_generation
-      parent-category: fatal_generation
+      ports:
+        - id: balance_port
+      parameters:
+        - id: available_power
+      extra-outputs:
+        - id: minus_generation
+        - id: generation_power
       properties:
         - id: technology
 
     - id: miscellaneous_fatal_generation
-      parent-category: fatal_generation
+      ports:
+        - id: balance_port
+      parameters:
+        - id: available_power
+      extra-outputs:
+        - id: minus_generation
+        - id: generation_power
       properties:
         - id: technology 
         - id: miscellaneous_type
@@ -88,7 +102,10 @@ taxonomy:
         - id: balance_port
 
     - id: fatal_consumption
-      parent-category: consumption
+      ports:
+        - id: balance_port
+      extra-outputs:
+        - id: actual_load
 
     - id: storage
       ports:
@@ -99,21 +116,38 @@ taxonomy:
         - id: level
     
     - id: long_term_storage
-      parent-category: storage
+      ports:
+        - id: balance_port
       variables:
+        - id: injection_power
+        - id: withdrawal_power
+        - id: level
         - id: overflow
       extra-outputs:
         - id: actual_inflows
         - id: level_percentage
-    
+
     - id: long_term_storage_with_watervalues
-      parent-category: long_term_storage
+      ports:
+        - id: balance_port
+      variables:
+        - id: injection_power
+        - id: withdrawal_power
+        - id: level
+        - id: overflow
       extra-outputs:
+        - id: actual_inflows
+        - id: level_percentage
         - id: hydro_shadow_price
         - id: bellman_value
-    
+
     - id: short_term_storage
-      parent-category: storage
+      ports:
+        - id: balance_port
+      variables:
+        - id: injection_power
+        - id: withdrawal_power
+        - id: level
       extra-outputs:
         - id: profit
       properties:

--- a/tests/antares_historic/test_catalogs.py
+++ b/tests/antares_historic/test_catalogs.py
@@ -79,6 +79,7 @@ def load_taxonomy_by_id(taxonomy_id):
 
 CATALOG_FILES = list(CATALOGS_DIR.glob("*.yml"))
 
+FLATTENED_TAXONOMY_FILE = TAXONOMIES_DIR / "antares_legacy_taxonomy_flattened.yml"
 
 @pytest.mark.parametrize("catalog_file", CATALOG_FILES)
 def test_metrics_output_ids_and_properties_are_declared(catalog_file):
@@ -89,6 +90,25 @@ def test_metrics_output_ids_and_properties_are_declared(catalog_file):
 
     taxonomy_index = build_taxonomy_index(taxonomy)
 
+    errors = find_taxonomy_errors(catalog, catalog_file, taxonomy_index)
+
+    assert not errors, "\n".join(errors)
+
+
+# The flattened taxonomy is provisional: it exists only until the view builder
+# supports parent categories, at which point it can be removed.
+@pytest.mark.parametrize("catalog_file", CATALOG_FILES)
+def test_metrics_output_ids_and_properties_are_declared_in_flattened_taxonomy(catalog_file):
+    catalog = load_yaml(catalog_file)
+
+    taxonomy = load_yaml(FLATTENED_TAXONOMY_FILE)
+    taxonomy_index = build_taxonomy_index(taxonomy)
+
+    errors = find_taxonomy_errors(catalog, catalog_file, taxonomy_index)
+
+    assert not errors, "\n".join(errors)
+
+def find_taxonomy_errors(catalog, catalog_file, taxonomy_index):
     errors = []
 
     for metric in catalog["catalog"]["metrics-definition"]:
@@ -136,4 +156,4 @@ def test_metrics_output_ids_and_properties_are_declared(catalog_file):
                         f"this property (nor any parent category)"
                     )
 
-    assert not errors, "\n".join(errors)
+    return errors


### PR DESCRIPTION
## Process ID

**Process:** A2G-02

## Description

Adds a flattened taxonomy (`antares_legacy_taxonomy_flattened.yml`) to ensure compatibility with the GEMS view builder, which does not yet support parent categories. This flattened taxonomy is provisional and can be removed once the view builder supports parent categories.

Also removes two unused entries (`coupling_models`, `capacity_investment_decisions`) from the main taxonomy.

## Impact Analysis

Only affects taxonomy files and catalog validation tests (`tests/antares_historic/test_catalogs.py`). No change to study conversion logic. No breaking changes.

## Checklist

- [x] Solver equivalence tests pass (`pytest tests/antares_historic/`)
- [x] `pyproject.toml` version bumped if converter logic changed
- [x] Changelog entry added if library changed (`CHANGELOG-antares_legacy_models_library.md`)
- [x] `COMPATIBILITY.md` updated if supported versions changed
- [x] Documentation updated or confirmed up to date
- [x] `AGENTS.md` reviewed for impact and updated if needed
